### PR TITLE
Remove unused base64 import

### DIFF
--- a/tco_app/app.py
+++ b/tco_app/app.py
@@ -10,7 +10,6 @@ Date: April 2025
 import streamlit as st
 import pandas as pd
 import os
-import base64
 # Remove the import for streamlit-tailwind since we're not using it
 # from streamlit_tailwind import st_tw
 


### PR DESCRIPTION
## Summary
- drop `base64` import from `tco_app/app.py`

## Testing
- `python3 -m py_compile tco_app/app.py`