### PR TITLE
Update setup instructions

### DIFF
--- a/tco_app/README.md
+++ b/tco_app/README.md
@@ -48,19 +48,25 @@ tco_app/
 ## Setup Instructions
 
 1. Clone this repository
-2. Install the required dependencies:
+2. Change to the `tco_app` directory:
+
+```bash
+cd tco_app
+```
+
+3. Install the required dependencies:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-3. Run the Streamlit application:
+4. Run the Streamlit application:
 
 ```bash
 streamlit run app.py
 ```
 
-4. Access the application in your web browser at http://localhost:8501
+5. Access the application in your web browser at http://localhost:8501
 
 ## Data Sources
 


### PR DESCRIPTION
## Summary
- clarify that users should `cd tco_app` before installing dependencies in the setup guide

## Testing
- `python -m compileall -q .`