### PR TITLE
Format codebase with Black

### DIFF
--- a/tco_app/domain/energy.py
+++ b/tco_app/domain/energy.py
@@ -50,19 +50,31 @@ def calculate_energy_costs(
         else:
             charging_option = safe_get_charging_option(charging_data, selected_charging)
             electricity_price = charging_option[DataColumns.PER_KWH_PRICE]
-        
+
         # Get diesel price
         diesel_price = safe_get_parameter(financial_params, ParameterKeys.DIESEL_PRICE)
-        
+
         # Calculate electric range ratio (assuming electric range is used first)
-        electric_range = vehicle_data.get(DataColumns.RANGE_KM, 50)  # Default 50km if not specified
+        electric_range = vehicle_data.get(
+            DataColumns.RANGE_KM, 50
+        )  # Default 50km if not specified
         # Assume typical daily driving of 100km, so electric portion is electric_range/100
         electric_ratio = min(electric_range / 100, 1.0)
         diesel_ratio = 1.0 - electric_ratio
-        
+
         # Calculate combined cost
-        electric_cost = vehicle_data[DataColumns.KWH_PER100KM] / 100 * electricity_price * electric_ratio
-        diesel_cost = vehicle_data[DataColumns.LITRES_PER100KM] / 100 * diesel_price * diesel_ratio
+        electric_cost = (
+            vehicle_data[DataColumns.KWH_PER100KM]
+            / 100
+            * electricity_price
+            * electric_ratio
+        )
+        diesel_cost = (
+            vehicle_data[DataColumns.LITRES_PER100KM]
+            / 100
+            * diesel_price
+            * diesel_ratio
+        )
         energy_cost_per_km = electric_cost + diesel_cost
     else:
         diesel_price = safe_get_parameter(financial_params, ParameterKeys.DIESEL_PRICE)

--- a/tco_app/plotters/cost_breakdown.py
+++ b/tco_app/plotters/cost_breakdown.py
@@ -5,6 +5,7 @@ from tco_app.src.constants import DataColumns, Drivetrain
 import plotly.express as px
 import plotly.graph_objects as go
 
+
 def create_cost_breakdown_chart(bev_results, diesel_results):
     """Create a stacked bar chart showing cost breakdown"""
     # Prepare data for BEV

--- a/tco_app/tests/e2e/test_full_tco_flow.py
+++ b/tco_app/tests/e2e/test_full_tco_flow.py
@@ -1,4 +1,5 @@
 """End-to-end tests for the complete TCO calculation flow."""
+
 import pytest
 import pandas as pd
 from unittest.mock import Mock
@@ -14,6 +15,7 @@ from tco_app.services.dtos import (
     ComparisonResult,
 )
 
+
 class TestFullTCOFlow:
     """Test complete TCO calculation flow from UI to results."""
 
@@ -22,133 +24,225 @@ class TestFullTCOFlow:
         """Mock all required repositories."""
         vehicle_repo = Mock(spec=VehicleRepository)
         params_repo = Mock(spec=ParametersRepository)
-        
+
         # Mock vehicle data
-        bev_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "MFTBC6X4BEV1",
-            DataColumns.VEHICLE_MODEL: "E-Actros 300",
-            DataColumns.VEHICLE_TYPE: "Medium Rigid",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BODY_TYPE: "Articulated",
-            DataColumns.BATTERY_CAPACITY_KWH: 540.0,
-            DataColumns.RANGE_KM: 300.0,
-            DataColumns.MSRP_PRICE: 380000,
-            DataColumns.BATTERY_EFFICIENCY: 0.9,
-            DataColumns.KWH_PER100KM: 80.0,  # Add energy consumption for BEV
-            DataColumns.PAYLOAD_T: 15.0,  # Add payload in tonnes
-        })
-        
-        diesel_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "MFTBC6X4DIESEL1",
-            DataColumns.VEHICLE_MODEL: "Actros",
-            DataColumns.VEHICLE_TYPE: "Medium Rigid",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.BODY_TYPE: "Articulated",
-            DataColumns.LITRES_PER100KM: 28.0,
-            DataColumns.MSRP_PRICE: 150000,
-            DataColumns.PAYLOAD_T: 15.0,  # Add payload in tonnes
-        })
-        
+        bev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "MFTBC6X4BEV1",
+                DataColumns.VEHICLE_MODEL: "E-Actros 300",
+                DataColumns.VEHICLE_TYPE: "Medium Rigid",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BODY_TYPE: "Articulated",
+                DataColumns.BATTERY_CAPACITY_KWH: 540.0,
+                DataColumns.RANGE_KM: 300.0,
+                DataColumns.MSRP_PRICE: 380000,
+                DataColumns.BATTERY_EFFICIENCY: 0.9,
+                DataColumns.KWH_PER100KM: 80.0,  # Add energy consumption for BEV
+                DataColumns.PAYLOAD_T: 15.0,  # Add payload in tonnes
+            }
+        )
+
+        diesel_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "MFTBC6X4DIESEL1",
+                DataColumns.VEHICLE_MODEL: "Actros",
+                DataColumns.VEHICLE_TYPE: "Medium Rigid",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.BODY_TYPE: "Articulated",
+                DataColumns.LITRES_PER100KM: 28.0,
+                DataColumns.MSRP_PRICE: 150000,
+                DataColumns.PAYLOAD_T: 15.0,  # Add payload in tonnes
+            }
+        )
+
         vehicle_repo.get_vehicle_by_id.side_effect = lambda id: (
             bev_vehicle if "BEV" in id else diesel_vehicle
         )
-        
+
         # Mock fees
-        bev_fees = pd.Series({
-            DataColumns.VEHICLE_ID: "MFTBC6X4BEV1",
-            'maintenance_perkm_price': 0.10,
-            DataColumns.REGISTRATION_ANNUAL_PRICE: 2000,
-            DataColumns.INSURANCE_ANNUAL_PRICE: 5000,
-            DataColumns.REGISTRATION_UPFRONT_PRICE: 500,
-            'stamp_duty_price': 3000,
-        })
-        
-        diesel_fees = pd.Series({
-            DataColumns.VEHICLE_ID: "MFTBC6X4DIESEL1",
-            'maintenance_perkm_price': 0.12,
-            DataColumns.REGISTRATION_ANNUAL_PRICE: 1800,
-            DataColumns.INSURANCE_ANNUAL_PRICE: 4500,
-            DataColumns.REGISTRATION_UPFRONT_PRICE: 450,
-            'stamp_duty_price': 2000,
-        })
-        
+        bev_fees = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "MFTBC6X4BEV1",
+                "maintenance_perkm_price": 0.10,
+                DataColumns.REGISTRATION_ANNUAL_PRICE: 2000,
+                DataColumns.INSURANCE_ANNUAL_PRICE: 5000,
+                DataColumns.REGISTRATION_UPFRONT_PRICE: 500,
+                "stamp_duty_price": 3000,
+            }
+        )
+
+        diesel_fees = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "MFTBC6X4DIESEL1",
+                "maintenance_perkm_price": 0.12,
+                DataColumns.REGISTRATION_ANNUAL_PRICE: 1800,
+                DataColumns.INSURANCE_ANNUAL_PRICE: 4500,
+                DataColumns.REGISTRATION_UPFRONT_PRICE: 450,
+                "stamp_duty_price": 2000,
+            }
+        )
+
         vehicle_repo.get_fees_by_vehicle_id.side_effect = lambda id: (
             bev_fees if "BEV" in id else diesel_fees
         )
-        
+
         # Mock financial parameters as DataFrame
-        financial_params = pd.DataFrame({
-            'financial_id': ['FP001', 'FP008', 'FP009', 'FP011', 'FP020'],  
-            'finance_description': ['discount_rate_percent', 'diesel_price', 'truck_life_years', 'annual_kms', 'residual_value_pct'],
-            'default_value': [0.05, 2.0, 10, 100000, 0.2],
-        })
+        financial_params = pd.DataFrame(
+            {
+                "financial_id": ["FP001", "FP008", "FP009", "FP011", "FP020"],
+                "finance_description": [
+                    "discount_rate_percent",
+                    "diesel_price",
+                    "truck_life_years",
+                    "annual_kms",
+                    "residual_value_pct",
+                ],
+                "default_value": [0.05, 2.0, 10, 100000, 0.2],
+            }
+        )
         params_repo.get_financial_params.return_value = financial_params
-        
+
         # Mock emission factors as DataFrame
-        emission_factors = pd.DataFrame({
-            'emissions_id': ['EF004', 'EF001'],
-            'fuel_type': ['electricity', 'diesel'],
-            'emission_standard': ['Grid', 'Euro IV+'],
-            'co2_per_unit': [0.7, 3.384],
-            'emissions_unit': ['kg_per_kwh', 'kg_per_litre'],
-        })
+        emission_factors = pd.DataFrame(
+            {
+                "emissions_id": ["EF004", "EF001"],
+                "fuel_type": ["electricity", "diesel"],
+                "emission_standard": ["Grid", "Euro IV+"],
+                "co2_per_unit": [0.7, 3.384],
+                "emissions_unit": ["kg_per_kwh", "kg_per_litre"],
+            }
+        )
         params_repo.get_emission_factors.return_value = emission_factors
-        
+
         # Mock battery parameters as DataFrame
-        battery_params = pd.DataFrame({
-            'battery_id': ['BP001', 'BP002', 'BP003', 'BP004'],
-            'battery_description': ['replacement_per_kwh_price', 'degradation_annual_percent', 
-                                    'minimum_capacity_percent', 'recycling_value_percent'],
-            'default_value': [150.0, 0.025, 0.7, 0.1],
-        })
+        battery_params = pd.DataFrame(
+            {
+                "battery_id": ["BP001", "BP002", "BP003", "BP004"],
+                "battery_description": [
+                    "replacement_per_kwh_price",
+                    "degradation_annual_percent",
+                    "minimum_capacity_percent",
+                    "recycling_value_percent",
+                ],
+                "default_value": [150.0, 0.025, 0.7, 0.1],
+            }
+        )
         params_repo.get_battery_params.return_value = battery_params
-        
+
         # Mock externalities data as DataFrame
-        externalities = pd.DataFrame({
-            'externality_id': ['EC003', 'EC004', 'EC009', 'EC010', 'EC021', 'EC022', 'EC025', 'EC026'],
-            'pollutant_type': ['noise_pollution', 'noise_pollution', 'pm25_pollution', 'pm25_pollution', 
-                               'air_pollution_total', 'air_pollution_total', 'externalities_total', 'externalities_total'],
-            'vehicle_class': ['Medium Rigid', 'Medium Rigid', 'Medium Rigid', 'Medium Rigid', 
-                              'Medium Rigid', 'Medium Rigid', 'Medium Rigid', 'Medium Rigid'],
-            'drivetrain': ['Diesel', 'BEV', 'Diesel', 'BEV', 'Diesel', 'BEV', 'Diesel', 'BEV'],
-            'cost_per_km': [0.017, 0.006, 0.048, 0.0, 0.113, 0.0, 0.150, 0.006],
-            'cost_unit': ['AUD/km', 'AUD/km', 'AUD/km', 'AUD/km', 'AUD/km', 'AUD/km', 'AUD/km', 'AUD/km'],
-            'year': [2025, 2025, 2025, 2025, 2025, 2025, 2025, 2025],
-            'calculation_basis': ['desc1', 'desc2', 'desc3', 'desc4', 'desc5', 'desc6', 'desc7', 'desc8'],
-        })
+        externalities = pd.DataFrame(
+            {
+                "externality_id": [
+                    "EC003",
+                    "EC004",
+                    "EC009",
+                    "EC010",
+                    "EC021",
+                    "EC022",
+                    "EC025",
+                    "EC026",
+                ],
+                "pollutant_type": [
+                    "noise_pollution",
+                    "noise_pollution",
+                    "pm25_pollution",
+                    "pm25_pollution",
+                    "air_pollution_total",
+                    "air_pollution_total",
+                    "externalities_total",
+                    "externalities_total",
+                ],
+                "vehicle_class": [
+                    "Medium Rigid",
+                    "Medium Rigid",
+                    "Medium Rigid",
+                    "Medium Rigid",
+                    "Medium Rigid",
+                    "Medium Rigid",
+                    "Medium Rigid",
+                    "Medium Rigid",
+                ],
+                "drivetrain": [
+                    "Diesel",
+                    "BEV",
+                    "Diesel",
+                    "BEV",
+                    "Diesel",
+                    "BEV",
+                    "Diesel",
+                    "BEV",
+                ],
+                "cost_per_km": [0.017, 0.006, 0.048, 0.0, 0.113, 0.0, 0.150, 0.006],
+                "cost_unit": [
+                    "AUD/km",
+                    "AUD/km",
+                    "AUD/km",
+                    "AUD/km",
+                    "AUD/km",
+                    "AUD/km",
+                    "AUD/km",
+                    "AUD/km",
+                ],
+                "year": [2025, 2025, 2025, 2025, 2025, 2025, 2025, 2025],
+                "calculation_basis": [
+                    "desc1",
+                    "desc2",
+                    "desc3",
+                    "desc4",
+                    "desc5",
+                    "desc6",
+                    "desc7",
+                    "desc8",
+                ],
+            }
+        )
         params_repo.get_externalities_data.return_value = externalities
-        
+
         # Mock charging options
-        charging_options = pd.DataFrame({
-            'charging_id': [1, 2, 3],
-            'charging_approach': ['Retail', 'Retail off-peak', 'Solar & Storage'],
-            'per_kwh_price': [0.3, 0.15, 0.04],
-            'charging_proportion': [0.2, 0.5, 0.3],
-        })
+        charging_options = pd.DataFrame(
+            {
+                "charging_id": [1, 2, 3],
+                "charging_approach": ["Retail", "Retail off-peak", "Solar & Storage"],
+                "per_kwh_price": [0.3, 0.15, 0.04],
+                "charging_proportion": [0.2, 0.5, 0.3],
+            }
+        )
         params_repo.get_charging_options.return_value = charging_options
-        
+
         # Mock infrastructure options
-        infrastructure_options = pd.DataFrame({
-            'infrastructure_id': [1, 2, 3],
-            'infrastructure_description': ['No Infrastructure', 'DC Fast Charger 80 kW', 'DC Fast Charger 160 kW'],
-            'infrastructure_price': [0, 55000, 90000],
-            'service_life_years': [15, 15, 15],
-            'maintenance_percent': [0, 0.03, 0.03],
-        })
+        infrastructure_options = pd.DataFrame(
+            {
+                "infrastructure_id": [1, 2, 3],
+                "infrastructure_description": [
+                    "No Infrastructure",
+                    "DC Fast Charger 80 kW",
+                    "DC Fast Charger 160 kW",
+                ],
+                "infrastructure_price": [0, 55000, 90000],
+                "service_life_years": [15, 15, 15],
+                "maintenance_percent": [0, 0.03, 0.03],
+            }
+        )
         params_repo.get_infrastructure_options.return_value = infrastructure_options
-        
+
         # Mock incentives data
-        incentives = pd.DataFrame({
-            'incentive_type': ['purchase_rebate', 'stamp_duty_exemption', 'registration_exemption'],
-            'incentive_value': [15000, 1.0, 1.0],
-            'incentive_rate': [0.0, 1.0, 1.0],
-            'drivetrain': ['BEV', 'BEV', 'BEV'],
-            'effective_date': ['2023-01-01', '2023-01-01', '2023-01-01'],
-            'expiry_date': ['2025-12-31', '2025-12-31', '2025-12-31'],
-            'incentive_flag': [1, 1, 1],
-        })
+        incentives = pd.DataFrame(
+            {
+                "incentive_type": [
+                    "purchase_rebate",
+                    "stamp_duty_exemption",
+                    "registration_exemption",
+                ],
+                "incentive_value": [15000, 1.0, 1.0],
+                "incentive_rate": [0.0, 1.0, 1.0],
+                "drivetrain": ["BEV", "BEV", "BEV"],
+                "effective_date": ["2023-01-01", "2023-01-01", "2023-01-01"],
+                "expiry_date": ["2025-12-31", "2025-12-31", "2025-12-31"],
+                "incentive_flag": [1, 1, 1],
+            }
+        )
         params_repo.get_incentives.return_value = incentives
-        
+
         return vehicle_repo, params_repo
 
     @pytest.fixture
@@ -161,132 +255,145 @@ class TestFullTCOFlow:
     def calculation_orchestrator(self, mock_repositories):
         """Create calculation orchestrator with mocked repositories."""
         vehicle_repo, params_repo = mock_repositories
-        
+
         # Create mock data tables - the CalculationOrchestrator will create its own repositories
         # but we'll mock them out
         data_tables = {}
         ui_context = {"modified_tables": data_tables}
-        
+
         orchestrator = CalculationOrchestrator(data_tables, ui_context)
-        
+
         # Replace the repositories with our mocks
         orchestrator.vehicle_repo = vehicle_repo
         orchestrator.params_repo = params_repo
         orchestrator.tco_service = TCOCalculationService(vehicle_repo, params_repo)
-        
+
         return orchestrator
 
     def test_single_vehicle_calculation_flow(self, calculation_orchestrator):
         """Test end-to-end flow for single vehicle calculation."""
         # Set UI context
         calculation_orchestrator.ui_context = {
-            'annual_kms': 100000,
-            'truck_life_years': 10,
-            'discount_rate': 0.05,
-            'selected_charging': 1,  # Should be an ID
-            'selected_infrastructure': 1,  # Should be an ID
-            'fleet_size': 10,
+            "annual_kms": 100000,
+            "truck_life_years": 10,
+            "discount_rate": 0.05,
+            "selected_charging": 1,  # Should be an ID
+            "selected_infrastructure": 1,  # Should be an ID
+            "fleet_size": 10,
         }
-        
+
         # Build calculation request for BEV
-        bev_request = calculation_orchestrator._build_calculation_request('MFTBC6X4BEV1')
-        
+        bev_request = calculation_orchestrator._build_calculation_request(
+            "MFTBC6X4BEV1"
+        )
+
         # Validate request structure
-        assert bev_request.vehicle_data[DataColumns.VEHICLE_ID] == 'MFTBC6X4BEV1'
+        assert bev_request.vehicle_data[DataColumns.VEHICLE_ID] == "MFTBC6X4BEV1"
         assert bev_request.parameters.annual_kms == 100000
         assert bev_request.parameters.truck_life_years == 10
-        
+
         # Perform calculation
-        result = calculation_orchestrator.tco_service.calculate_single_vehicle_tco(bev_request)
-        
+        result = calculation_orchestrator.tco_service.calculate_single_vehicle_tco(
+            bev_request
+        )
+
         # Validate result
         assert isinstance(result, TCOResult)
-        assert result.vehicle_id == 'MFTBC6X4BEV1'
+        assert result.vehicle_id == "MFTBC6X4BEV1"
         assert result.tco_total_lifetime > 0
         assert result.tco_per_km > 0
-        
+
     def test_comparison_calculation_flow(self, calculation_orchestrator):
         """Test end-to-end flow for vehicle comparison."""
         # Set UI context
         calculation_orchestrator.ui_context = {
-            'annual_kms': 100000,
-            'truck_life_years': 10,
-            'discount_rate': 0.05,
-            'selected_charging': 1,
-            'selected_infrastructure': 1,
-            'fleet_size': 10,
+            "annual_kms": 100000,
+            "truck_life_years": 10,
+            "discount_rate": 0.05,
+            "selected_charging": 1,
+            "selected_infrastructure": 1,
+            "fleet_size": 10,
         }
-        
+
         # Build calculation requests for both vehicles
-        bev_request = calculation_orchestrator._build_calculation_request('MFTBC6X4BEV1')
-        diesel_request = calculation_orchestrator._build_calculation_request('MFTBC6X4DIESEL1')
-        
+        bev_request = calculation_orchestrator._build_calculation_request(
+            "MFTBC6X4BEV1"
+        )
+        diesel_request = calculation_orchestrator._build_calculation_request(
+            "MFTBC6X4DIESEL1"
+        )
+
         # Compare BEV vs Diesel
         comparison = calculation_orchestrator.tco_service.compare_vehicles(
-            bev_request,
-            diesel_request
+            bev_request, diesel_request
         )
-        
+
         # Validate comparison results
         assert isinstance(comparison, ComparisonResult)
-        assert comparison.base_vehicle_result.vehicle_id == 'MFTBC6X4BEV1'
-        assert comparison.comparison_vehicle_result.vehicle_id == 'MFTBC6X4DIESEL1'
+        assert comparison.base_vehicle_result.vehicle_id == "MFTBC6X4BEV1"
+        assert comparison.comparison_vehicle_result.vehicle_id == "MFTBC6X4DIESEL1"
         assert comparison.tco_savings_lifetime != 0
-        
+
         # Validate TCO difference calculation
-        expected_savings = (comparison.comparison_vehicle_result.tco_total_lifetime - 
-                          comparison.base_vehicle_result.tco_total_lifetime)
+        expected_savings = (
+            comparison.comparison_vehicle_result.tco_total_lifetime
+            - comparison.base_vehicle_result.tco_total_lifetime
+        )
         assert abs(comparison.tco_savings_lifetime - expected_savings) < 0.01
-        
+
     def test_sensitivity_analysis_flow(self, calculation_orchestrator):
         """Test sensitivity analysis with parameter variations."""
         # Set UI context
         calculation_orchestrator.ui_context = {
-            'annual_kms': 100000,
-            'truck_life_years': 10,
-            'discount_rate': 0.05,
-            'selected_charging': 1,
-            'selected_infrastructure': 1,
-            'fleet_size': 10,
+            "annual_kms": 100000,
+            "truck_life_years": 10,
+            "discount_rate": 0.05,
+            "selected_charging": 1,
+            "selected_infrastructure": 1,
+            "fleet_size": 10,
         }
-        
+
         # Calculate baseline
-        baseline_result = calculation_orchestrator.tco_service.calculate_single_vehicle_tco(
-            calculation_orchestrator._build_calculation_request('MFTBC6X4BEV1')
+        baseline_result = (
+            calculation_orchestrator.tco_service.calculate_single_vehicle_tco(
+                calculation_orchestrator._build_calculation_request("MFTBC6X4BEV1")
+            )
         )
-        
+
         # Update context with higher kms
-        calculation_orchestrator.ui_context['annual_kms'] = 150000
-        
+        calculation_orchestrator.ui_context["annual_kms"] = 150000
+
         # Calculate with higher kms
-        high_kms_result = calculation_orchestrator.tco_service.calculate_single_vehicle_tco(
-            calculation_orchestrator._build_calculation_request('MFTBC6X4BEV1')
+        high_kms_result = (
+            calculation_orchestrator.tco_service.calculate_single_vehicle_tco(
+                calculation_orchestrator._build_calculation_request("MFTBC6X4BEV1")
+            )
         )
-        
+
         # Validate sensitivity impact
         assert high_kms_result.tco_total_lifetime > baseline_result.tco_total_lifetime
         # Cost per km should be lower with higher utilization
         assert high_kms_result.tco_per_km < baseline_result.tco_per_km
-        
+
     def test_fleet_size_impact(self, calculation_orchestrator):
         """Test impact of fleet size on infrastructure costs."""
         fleet_sizes = [1, 10, 50]
         previous_infra_cost = 0
-        
+
         for fleet_size in fleet_sizes:
             calculation_orchestrator.ui_context = {
-                'annual_kms': 100000,
-                'truck_life_years': 10,
-                'discount_rate': 0.05,
-                'selected_charging': 1,
-                'selected_infrastructure': 1,
-                'fleet_size': fleet_size,
+                "annual_kms": 100000,
+                "truck_life_years": 10,
+                "discount_rate": 0.05,
+                "selected_charging": 1,
+                "selected_infrastructure": 1,
+                "fleet_size": fleet_size,
             }
-            
+
             result = calculation_orchestrator.tco_service.calculate_single_vehicle_tco(
-                calculation_orchestrator._build_calculation_request('MFTBC6X4BEV1')
+                calculation_orchestrator._build_calculation_request("MFTBC6X4BEV1")
             )
-            
+
             # Infrastructure cost per vehicle should decrease with fleet size
             infra_cost_per_vehicle = result.npv_infrastructure_cost
             if previous_infra_cost > 0:

--- a/tco_app/tests/unit/domain/sensitivity/test_metrics.py
+++ b/tco_app/tests/unit/domain/sensitivity/test_metrics.py
@@ -14,41 +14,41 @@ class TestCalculateComparativeMetrics:
     def base_bev_results(self):
         """Basic BEV results for testing."""
         return {
-            'acquisition_cost': 380000,
-            'residual_value': 70000,
-            'annual_costs': {
-                'annual_operating_cost': 58000,
-                'annual_energy_cost': 25000,
-                'annual_maintenance_cost': 8000,
+            "acquisition_cost": 380000,
+            "residual_value": 70000,
+            "annual_costs": {
+                "annual_operating_cost": 58000,
+                "annual_energy_cost": 25000,
+                "annual_maintenance_cost": 8000,
             },
-            'emissions': {
-                'lifetime_emissions': 625000,
-                'annual_emissions': 62500,
+            "emissions": {
+                "lifetime_emissions": 625000,
+                "annual_emissions": 62500,
             },
-            'tco': {
-                'npv_total_cost': 750000,
+            "tco": {
+                "npv_total_cost": 750000,
             },
-            'battery_replacement_year': 8,
-            'battery_replacement_cost': 150000,
+            "battery_replacement_year": 8,
+            "battery_replacement_cost": 150000,
         }
 
     @pytest.fixture
     def base_diesel_results(self):
         """Basic diesel results for testing."""
         return {
-            'acquisition_cost': 150000,
-            'residual_value': 30000,
-            'annual_costs': {
-                'annual_operating_cost': 75000,
-                'annual_energy_cost': 52500,
-                'annual_maintenance_cost': 10000,
+            "acquisition_cost": 150000,
+            "residual_value": 30000,
+            "annual_costs": {
+                "annual_operating_cost": 75000,
+                "annual_energy_cost": 52500,
+                "annual_maintenance_cost": 10000,
             },
-            'emissions': {
-                'lifetime_emissions': 938000,
-                'annual_emissions': 93800,
+            "emissions": {
+                "lifetime_emissions": 938000,
+                "annual_emissions": 93800,
             },
-            'tco': {
-                'npv_total_cost': 850000,
+            "tco": {
+                "npv_total_cost": 850000,
             },
         }
 
@@ -58,271 +58,277 @@ class TestCalculateComparativeMetrics:
             bev_results=base_bev_results,
             diesel_results=base_diesel_results,
             annual_kms=100000,
-            truck_life_years=10
+            truck_life_years=10,
         )
 
         # Test upfront cost difference
         expected_upfront_diff = 380000 - 150000
-        assert metrics['upfront_cost_difference'] == expected_upfront_diff
+        assert metrics["upfront_cost_difference"] == expected_upfront_diff
 
         # Test annual operating savings (diesel cost - bev cost)
         expected_annual_savings = 75000 - 58000
-        assert metrics['annual_operating_savings'] == expected_annual_savings
+        assert metrics["annual_operating_savings"] == expected_annual_savings
 
         # Test emission savings
         expected_emission_savings = 938000 - 625000
-        assert metrics['emission_savings_lifetime'] == expected_emission_savings
+        assert metrics["emission_savings_lifetime"] == expected_emission_savings
 
         # Test BEV to diesel ratio
         expected_ratio = 750000 / 850000
-        assert metrics['bev_to_diesel_tco_ratio'] == pytest.approx(expected_ratio, rel=1e-5)
+        assert metrics["bev_to_diesel_tco_ratio"] == pytest.approx(
+            expected_ratio, rel=1e-5
+        )
 
         # Test abatement cost
         expected_abatement = (750000 - 850000) / (313)  # emissions in tonnes
-        assert metrics['abatement_cost'] == pytest.approx(expected_abatement, rel=1e-2)
+        assert metrics["abatement_cost"] == pytest.approx(expected_abatement, rel=1e-2)
 
     def test_price_parity_calculation(self):
         """Test price parity year calculation with specific cash flows."""
         # Create results where BEV becomes cheaper after year 5
         bev_results = {
-            'acquisition_cost': 200000,
-            'residual_value': 40000,
-            'annual_costs': {'annual_operating_cost': 20000},
-            'emissions': {'lifetime_emissions': 500000},
-            'tco': {'npv_total_cost': 350000},
+            "acquisition_cost": 200000,
+            "residual_value": 40000,
+            "annual_costs": {"annual_operating_cost": 20000},
+            "emissions": {"lifetime_emissions": 500000},
+            "tco": {"npv_total_cost": 350000},
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 100000,
-            'residual_value': 20000,
-            'annual_costs': {'annual_operating_cost': 30000},
-            'emissions': {'lifetime_emissions': 800000},
-            'tco': {'npv_total_cost': 380000},
+            "acquisition_cost": 100000,
+            "residual_value": 20000,
+            "annual_costs": {"annual_operating_cost": 30000},
+            "emissions": {"lifetime_emissions": 800000},
+            "tco": {"npv_total_cost": 380000},
         }
 
         metrics = calculate_comparative_metrics(
             bev_results=bev_results,
             diesel_results=diesel_results,
             annual_kms=100000,
-            truck_life_years=10
+            truck_life_years=10,
         )
 
         # With 100k upfront difference and 10k annual savings, parity should be at year 10
-        # However, due to residual value adjustments in the final year, the actual crossover 
+        # However, due to residual value adjustments in the final year, the actual crossover
         # happens slightly earlier at approximately 9.67 years
-        assert pytest.approx(metrics['price_parity_year'], rel=1e-3) == 9.666666666666666
+        assert (
+            pytest.approx(metrics["price_parity_year"], rel=1e-3) == 9.666666666666666
+        )
 
     def test_with_infrastructure_costs(self):
         """Test metrics calculation including infrastructure costs."""
         bev_results = {
-            'acquisition_cost': 380000,
-            'residual_value': 70000,
-            'annual_costs': {'annual_operating_cost': 58000},
-            'emissions': {'lifetime_emissions': 625000},
-            'tco': {'npv_total_cost': 800000},
-            'infrastructure_costs': {
+            "acquisition_cost": 380000,
+            "residual_value": 70000,
+            "annual_costs": {"annual_operating_cost": 58000},
+            "emissions": {"lifetime_emissions": 625000},
+            "tco": {"npv_total_cost": 800000},
+            "infrastructure_costs": {
                 DataColumns.INFRASTRUCTURE_PRICE: 50000,
-                'infrastructure_price_with_incentives': 40000,
-                'fleet_size': 10,
-                'annual_maintenance': 2000,
-                'service_life_years': 15,
-            }
+                "infrastructure_price_with_incentives": 40000,
+                "fleet_size": 10,
+                "annual_maintenance": 2000,
+                "service_life_years": 15,
+            },
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 150000,
-            'residual_value': 30000,
-            'annual_costs': {'annual_operating_cost': 75000},
-            'emissions': {'lifetime_emissions': 938000},
-            'tco': {'npv_total_cost': 850000},
+            "acquisition_cost": 150000,
+            "residual_value": 30000,
+            "annual_costs": {"annual_operating_cost": 75000},
+            "emissions": {"lifetime_emissions": 938000},
+            "tco": {"npv_total_cost": 850000},
         }
 
         metrics = calculate_comparative_metrics(
             bev_results=bev_results,
             diesel_results=diesel_results,
             annual_kms=100000,
-            truck_life_years=10
+            truck_life_years=10,
         )
 
         # Infrastructure cost per vehicle (40000 / 10 = 4000) should be added to upfront cost
         expected_upfront_diff = (380000 + 4000) - 150000
-        assert metrics['upfront_cost_difference'] == expected_upfront_diff
+        assert metrics["upfront_cost_difference"] == expected_upfront_diff
 
     def test_battery_replacement_impact(self):
         """Test impact of battery replacement on cumulative costs."""
         bev_results = {
-            'acquisition_cost': 380000,
-            'residual_value': 70000,
-            'annual_costs': {'annual_operating_cost': 58000},
-            'emissions': {'lifetime_emissions': 625000},
-            'tco': {'npv_total_cost': 900000},
-            'battery_replacement_year': 5,
-            'battery_replacement_cost': 100000,
+            "acquisition_cost": 380000,
+            "residual_value": 70000,
+            "annual_costs": {"annual_operating_cost": 58000},
+            "emissions": {"lifetime_emissions": 625000},
+            "tco": {"npv_total_cost": 900000},
+            "battery_replacement_year": 5,
+            "battery_replacement_cost": 100000,
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 150000,
-            'residual_value': 30000,
-            'annual_costs': {'annual_operating_cost': 75000},
-            'emissions': {'lifetime_emissions': 938000},
-            'tco': {'npv_total_cost': 850000},
+            "acquisition_cost": 150000,
+            "residual_value": 30000,
+            "annual_costs": {"annual_operating_cost": 75000},
+            "emissions": {"lifetime_emissions": 938000},
+            "tco": {"npv_total_cost": 850000},
         }
 
         metrics = calculate_comparative_metrics(
             bev_results=bev_results,
             diesel_results=diesel_results,
             annual_kms=100000,
-            truck_life_years=10
+            truck_life_years=10,
         )
 
         # The battery replacement should affect the price parity year
-        assert metrics['price_parity_year'] > 10  # Should be pushed beyond 10 years
+        assert metrics["price_parity_year"] > 10  # Should be pushed beyond 10 years
 
     def test_zero_emission_savings(self):
         """Test handling of zero emission savings."""
         bev_results = {
-            'acquisition_cost': 380000,
-            'residual_value': 70000,
-            'annual_costs': {'annual_operating_cost': 58000},
-            'emissions': {'lifetime_emissions': 625000},
-            'tco': {'npv_total_cost': 750000},
+            "acquisition_cost": 380000,
+            "residual_value": 70000,
+            "annual_costs": {"annual_operating_cost": 58000},
+            "emissions": {"lifetime_emissions": 625000},
+            "tco": {"npv_total_cost": 750000},
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 150000,
-            'residual_value': 30000,
-            'annual_costs': {'annual_operating_cost': 75000},
-            'emissions': {'lifetime_emissions': 625000},  # Same as BEV
-            'tco': {'npv_total_cost': 850000},
+            "acquisition_cost": 150000,
+            "residual_value": 30000,
+            "annual_costs": {"annual_operating_cost": 75000},
+            "emissions": {"lifetime_emissions": 625000},  # Same as BEV
+            "tco": {"npv_total_cost": 850000},
         }
 
         metrics = calculate_comparative_metrics(
             bev_results=bev_results,
             diesel_results=diesel_results,
             annual_kms=100000,
-            truck_life_years=10
+            truck_life_years=10,
         )
 
         # Abatement cost should be infinity when no emission savings
-        assert metrics['abatement_cost'] == float('inf')
-        assert metrics['emission_savings_lifetime'] == 0
+        assert metrics["abatement_cost"] == float("inf")
+        assert metrics["emission_savings_lifetime"] == 0
 
     def test_no_price_parity_within_lifetime(self):
         """Test when BEV never reaches price parity."""
         bev_results = {
-            'acquisition_cost': 500000,  # Very expensive BEV
-            'residual_value': 100000,
-            'annual_costs': {'annual_operating_cost': 70000},  # Only slightly cheaper annually
-            'emissions': {'lifetime_emissions': 625000},
-            'tco': {'npv_total_cost': 1100000},
+            "acquisition_cost": 500000,  # Very expensive BEV
+            "residual_value": 100000,
+            "annual_costs": {
+                "annual_operating_cost": 70000
+            },  # Only slightly cheaper annually
+            "emissions": {"lifetime_emissions": 625000},
+            "tco": {"npv_total_cost": 1100000},
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 150000,
-            'residual_value': 30000,
-            'annual_costs': {'annual_operating_cost': 75000},
-            'emissions': {'lifetime_emissions': 938000},
-            'tco': {'npv_total_cost': 850000},
+            "acquisition_cost": 150000,
+            "residual_value": 30000,
+            "annual_costs": {"annual_operating_cost": 75000},
+            "emissions": {"lifetime_emissions": 938000},
+            "tco": {"npv_total_cost": 850000},
         }
 
         metrics = calculate_comparative_metrics(
             bev_results=bev_results,
             diesel_results=diesel_results,
             annual_kms=100000,
-            truck_life_years=10
+            truck_life_years=10,
         )
 
         # Price parity should be infinity if never reached
-        assert metrics['price_parity_year'] == math.inf
+        assert metrics["price_parity_year"] == math.inf
 
     def test_infrastructure_replacement_cycle(self):
         """Test infrastructure replacement impact on costs."""
         bev_results = {
-            'acquisition_cost': 380000,
-            'residual_value': 70000,
-            'annual_costs': {'annual_operating_cost': 58000},
-            'emissions': {'lifetime_emissions': 625000},
-            'tco': {'npv_total_cost': 850000},
-            'infrastructure_costs': {
+            "acquisition_cost": 380000,
+            "residual_value": 70000,
+            "annual_costs": {"annual_operating_cost": 58000},
+            "emissions": {"lifetime_emissions": 625000},
+            "tco": {"npv_total_cost": 850000},
+            "infrastructure_costs": {
                 DataColumns.INFRASTRUCTURE_PRICE: 60000,
-                'infrastructure_price_with_incentives': None,  # No incentives
-                'fleet_size': 5,
-                'annual_maintenance': 3000,
-                'service_life_years': 5,  # Replacement every 5 years
-            }
+                "infrastructure_price_with_incentives": None,  # No incentives
+                "fleet_size": 5,
+                "annual_maintenance": 3000,
+                "service_life_years": 5,  # Replacement every 5 years
+            },
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 150000,
-            'residual_value': 30000,
-            'annual_costs': {'annual_operating_cost': 75000},
-            'emissions': {'lifetime_emissions': 938000},
-            'tco': {'npv_total_cost': 850000},
+            "acquisition_cost": 150000,
+            "residual_value": 30000,
+            "annual_costs": {"annual_operating_cost": 75000},
+            "emissions": {"lifetime_emissions": 938000},
+            "tco": {"npv_total_cost": 850000},
         }
 
         metrics = calculate_comparative_metrics(
             bev_results=bev_results,
             diesel_results=diesel_results,
             annual_kms=100000,
-            truck_life_years=10
+            truck_life_years=10,
         )
 
         # With infrastructure replacement at year 5, price parity should be delayed
-        assert metrics['price_parity_year'] > 10
+        assert metrics["price_parity_year"] > 10
 
     def test_edge_case_single_year_lifetime(self):
         """Test edge case with single year truck lifetime."""
         bev_results = {
-            'acquisition_cost': 380000,
-            'residual_value': 350000,  # High residual for 1 year
-            'annual_costs': {'annual_operating_cost': 58000},
-            'emissions': {'lifetime_emissions': 62500},
-            'tco': {'npv_total_cost': 88000},
+            "acquisition_cost": 380000,
+            "residual_value": 350000,  # High residual for 1 year
+            "annual_costs": {"annual_operating_cost": 58000},
+            "emissions": {"lifetime_emissions": 62500},
+            "tco": {"npv_total_cost": 88000},
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 150000,
-            'residual_value': 140000,
-            'annual_costs': {'annual_operating_cost': 75000},
-            'emissions': {'lifetime_emissions': 93800},
-            'tco': {'npv_total_cost': 85000},
+            "acquisition_cost": 150000,
+            "residual_value": 140000,
+            "annual_costs": {"annual_operating_cost": 75000},
+            "emissions": {"lifetime_emissions": 93800},
+            "tco": {"npv_total_cost": 85000},
         }
 
         metrics = calculate_comparative_metrics(
             bev_results=bev_results,
             diesel_results=diesel_results,
             annual_kms=100000,
-            truck_life_years=1
+            truck_life_years=1,
         )
 
         # With only 1 year, price parity calculation should handle edge case
-        assert 'price_parity_year' in metrics
-        assert 'upfront_cost_difference' in metrics
+        assert "price_parity_year" in metrics
+        assert "upfront_cost_difference" in metrics
 
     def test_negative_npv_scenario(self):
         """Test handling of negative NPV values."""
         bev_results = {
-            'acquisition_cost': 100000,
-            'residual_value': 200000,  # Very high residual value
-            'annual_costs': {'annual_operating_cost': 20000},
-            'emissions': {'lifetime_emissions': 625000},
-            'tco': {'npv_total_cost': -50000},  # Negative NPV
+            "acquisition_cost": 100000,
+            "residual_value": 200000,  # Very high residual value
+            "annual_costs": {"annual_operating_cost": 20000},
+            "emissions": {"lifetime_emissions": 625000},
+            "tco": {"npv_total_cost": -50000},  # Negative NPV
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 150000,
-            'residual_value': 30000,
-            'annual_costs': {'annual_operating_cost': 75000},
-            'emissions': {'lifetime_emissions': 938000},
-            'tco': {'npv_total_cost': 850000},
+            "acquisition_cost": 150000,
+            "residual_value": 30000,
+            "annual_costs": {"annual_operating_cost": 75000},
+            "emissions": {"lifetime_emissions": 938000},
+            "tco": {"npv_total_cost": 850000},
         }
 
         metrics = calculate_comparative_metrics(
             bev_results=bev_results,
             diesel_results=diesel_results,
             annual_kms=100000,
-            truck_life_years=10
+            truck_life_years=10,
         )
 
         # Should handle negative NPV correctly
-        assert metrics['bev_to_diesel_tco_ratio'] < 0
+        assert metrics["bev_to_diesel_tco_ratio"] < 0

--- a/tco_app/tests/unit/domain/test_energy.py
+++ b/tco_app/tests/unit/domain/test_energy.py
@@ -67,8 +67,10 @@ class TestEnergyCalculations:
         standard_financial_params,
     ):
         """Test BEV energy cost with missing charging option."""
-        empty_charging = pd.DataFrame(columns=[DataColumns.CHARGING_ID, DataColumns.PER_KWH_PRICE])
-        
+        empty_charging = pd.DataFrame(
+            columns=[DataColumns.CHARGING_ID, DataColumns.PER_KWH_PRICE]
+        )
+
         with pytest.raises(Exception):  # Should raise when charging option not found
             calculate_energy_costs(
                 articulated_bev_vehicle,
@@ -80,29 +82,37 @@ class TestEnergyCalculations:
 
     def test_energy_costs_phev_vehicle(self):
         """Test PHEV energy cost calculation (hybrid mode)."""
-        phev_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "phev_truck",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.PHEV,
-            DataColumns.LITRES_PER100KM: 20.0,  # L/100km
-            DataColumns.KWH_PER100KM: 15.0,  # kWh/100km for electric mode
-            DataColumns.BATTERY_CAPACITY_KWH: 30.0,
-            DataColumns.RANGE_KM: 50.0,  # 50km electric range
-        })
-        
-        fees = pd.Series({
-            DataColumns.REGISTRATION_ANNUAL_PRICE: 1000,
-        })
-        
-        charging = pd.DataFrame({
-            DataColumns.CHARGING_ID: ["Depot"],
-            DataColumns.PER_KWH_PRICE: [0.25],
-        })
-        
-        financial = pd.DataFrame({
-            DataColumns.FINANCE_DESCRIPTION: [ParameterKeys.DIESEL_PRICE],
-            DataColumns.FINANCE_DEFAULT_VALUE: [2.0],
-        })
-        
+        phev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "phev_truck",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.PHEV,
+                DataColumns.LITRES_PER100KM: 20.0,  # L/100km
+                DataColumns.KWH_PER100KM: 15.0,  # kWh/100km for electric mode
+                DataColumns.BATTERY_CAPACITY_KWH: 30.0,
+                DataColumns.RANGE_KM: 50.0,  # 50km electric range
+            }
+        )
+
+        fees = pd.Series(
+            {
+                DataColumns.REGISTRATION_ANNUAL_PRICE: 1000,
+            }
+        )
+
+        charging = pd.DataFrame(
+            {
+                DataColumns.CHARGING_ID: ["Depot"],
+                DataColumns.PER_KWH_PRICE: [0.25],
+            }
+        )
+
+        financial = pd.DataFrame(
+            {
+                DataColumns.FINANCE_DESCRIPTION: [ParameterKeys.DIESEL_PRICE],
+                DataColumns.FINANCE_DEFAULT_VALUE: [2.0],
+            }
+        )
+
         # PHEV should use combination of electric and diesel
         cost = calculate_energy_costs(
             phev_vehicle,
@@ -111,33 +121,39 @@ class TestEnergyCalculations:
             financial,
             selected_charging="Depot",
         )
-        
+
         # Cost should be between pure electric and pure diesel
         assert cost > 0
         assert cost < (0.20 * 2.0)  # Less than pure diesel
 
     def test_energy_costs_with_battery_inefficiency(self):
         """Test energy cost calculation with battery efficiency."""
-        bev_with_efficiency = pd.Series({
-            DataColumns.VEHICLE_ID: "bev_eff",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: 540.0,
-            DataColumns.RANGE_KM: 300.0,
-            DataColumns.BATTERY_EFFICIENCY: 0.85,  # 85% efficiency
-        })
-        
+        bev_with_efficiency = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "bev_eff",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: 540.0,
+                DataColumns.RANGE_KM: 300.0,
+                DataColumns.BATTERY_EFFICIENCY: 0.85,  # 85% efficiency
+            }
+        )
+
         fees = pd.Series({DataColumns.REGISTRATION_ANNUAL_PRICE: 0})
-        
-        charging = pd.DataFrame({
-            DataColumns.CHARGING_ID: ["Depot"],
-            DataColumns.PER_KWH_PRICE: [0.25],
-        })
-        
-        financial = pd.DataFrame({
-            DataColumns.FINANCE_DESCRIPTION: [ParameterKeys.DIESEL_PRICE],
-            DataColumns.FINANCE_DEFAULT_VALUE: [2.0],
-        })
-        
+
+        charging = pd.DataFrame(
+            {
+                DataColumns.CHARGING_ID: ["Depot"],
+                DataColumns.PER_KWH_PRICE: [0.25],
+            }
+        )
+
+        financial = pd.DataFrame(
+            {
+                DataColumns.FINANCE_DESCRIPTION: [ParameterKeys.DIESEL_PRICE],
+                DataColumns.FINANCE_DEFAULT_VALUE: [2.0],
+            }
+        )
+
         cost = calculate_energy_costs(
             bev_with_efficiency,
             fees,
@@ -145,7 +161,7 @@ class TestEnergyCalculations:
             financial,
             selected_charging="Depot",
         )
-        
+
         # Cost should account for efficiency loss
         # 540kWh / 300km = 180 kWh/100km, with 85% efficiency = 211.76 kWh/100km from grid
         expected = (180 / 0.85 / 100) * 0.25
@@ -174,22 +190,24 @@ class TestEmissionsCalculations:
 
     def test_emissions_with_zero_grid_factor(self):
         """Test BEV emissions with zero grid emission factor (100% renewable)."""
-        bev_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "bev_clean",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: 540.0,
-            DataColumns.RANGE_KM: 300.0,
-        })
-        
-        zero_emission_factors = pd.Series({
-            DataColumns.GRID_EMISSION_FACTOR: 0.0,  # 100% renewable
-            DataColumns.DIESEL_EMISSION_FACTOR: 2.7,
-        })
-        
-        emissions = calculate_emissions(
-            bev_vehicle, zero_emission_factors, 100_000, 10
+        bev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "bev_clean",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: 540.0,
+                DataColumns.RANGE_KM: 300.0,
+            }
         )
-        
+
+        zero_emission_factors = pd.Series(
+            {
+                DataColumns.GRID_EMISSION_FACTOR: 0.0,  # 100% renewable
+                DataColumns.DIESEL_EMISSION_FACTOR: 2.7,
+            }
+        )
+
+        emissions = calculate_emissions(bev_vehicle, zero_emission_factors, 100_000, 10)
+
         # With zero grid factor, BEV should have zero emissions
         assert emissions["co2_per_km"] == 0.0
         assert emissions["lifetime_emissions"] == 0.0
@@ -197,22 +215,24 @@ class TestEmissionsCalculations:
 
     def test_emissions_with_high_grid_factor(self):
         """Test BEV emissions with very high grid emission factor."""
-        bev_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "bev_dirty",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: 540.0,
-            DataColumns.RANGE_KM: 300.0,
-        })
-        
-        high_emission_factors = pd.Series({
-            DataColumns.GRID_EMISSION_FACTOR: 1.0,  # Very dirty grid (1kg CO2/kWh)
-            DataColumns.DIESEL_EMISSION_FACTOR: 2.7,
-        })
-        
-        emissions = calculate_emissions(
-            bev_vehicle, high_emission_factors, 100_000, 10
+        bev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "bev_dirty",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: 540.0,
+                DataColumns.RANGE_KM: 300.0,
+            }
         )
-        
+
+        high_emission_factors = pd.Series(
+            {
+                DataColumns.GRID_EMISSION_FACTOR: 1.0,  # Very dirty grid (1kg CO2/kWh)
+                DataColumns.DIESEL_EMISSION_FACTOR: 2.7,
+            }
+        )
+
+        emissions = calculate_emissions(bev_vehicle, high_emission_factors, 100_000, 10)
+
         # Even with dirty grid, calculations should work
         assert emissions["co2_per_km"] > 0
         assert emissions["lifetime_emissions"] > 0
@@ -221,41 +241,47 @@ class TestEmissionsCalculations:
 
     def test_emissions_phev_vehicle(self):
         """Test PHEV emissions calculation."""
-        phev_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "phev",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.PHEV,
-            DataColumns.LITRES_PER100KM: 20.0,
-            DataColumns.BATTERY_CAPACITY_KWH: 30.0,
-            DataColumns.RANGE_KM: 50.0,  # 50km electric range
-        })
-        
-        emission_factors = pd.Series({
-            DataColumns.GRID_EMISSION_FACTOR: 0.5,
-            DataColumns.DIESEL_EMISSION_FACTOR: 2.7,
-        })
-        
-        emissions = calculate_emissions(
-            phev_vehicle, emission_factors, 100_000, 10
+        phev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "phev",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.PHEV,
+                DataColumns.LITRES_PER100KM: 20.0,
+                DataColumns.BATTERY_CAPACITY_KWH: 30.0,
+                DataColumns.RANGE_KM: 50.0,  # 50km electric range
+            }
         )
-        
+
+        emission_factors = pd.Series(
+            {
+                DataColumns.GRID_EMISSION_FACTOR: 0.5,
+                DataColumns.DIESEL_EMISSION_FACTOR: 2.7,
+            }
+        )
+
+        emissions = calculate_emissions(phev_vehicle, emission_factors, 100_000, 10)
+
         # PHEV emissions should be between BEV and diesel
         assert emissions["co2_per_km"] > 0
         assert emissions["co2_per_km"] < (0.20 * 2.7)  # Less than pure diesel
 
     def test_emissions_with_negative_values(self):
         """Test emissions calculation with invalid negative values."""
-        vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "invalid",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: -100.0,  # Invalid negative
-            DataColumns.RANGE_KM: 300.0,
-        })
-        
-        emission_factors = pd.Series({
-            DataColumns.GRID_EMISSION_FACTOR: 0.5,
-            DataColumns.DIESEL_EMISSION_FACTOR: 2.7,
-        })
-        
+        vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "invalid",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: -100.0,  # Invalid negative
+                DataColumns.RANGE_KM: 300.0,
+            }
+        )
+
+        emission_factors = pd.Series(
+            {
+                DataColumns.GRID_EMISSION_FACTOR: 0.5,
+                DataColumns.DIESEL_EMISSION_FACTOR: 2.7,
+            }
+        )
+
         # Should handle gracefully or raise appropriate error
         with pytest.raises(Exception):
             calculate_emissions(vehicle, emission_factors, 100_000, 10)
@@ -277,92 +303,108 @@ class TestChargingRequirements:
 
     def test_charging_requirements_high_utilization(self):
         """Test charging requirements with high daily utilization."""
-        high_util_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "high_util",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: 540.0,
-            DataColumns.RANGE_KM: 300.0,
-            DataColumns.BATTERY_EFFICIENCY: 0.9,
-        })
-        
-        infra = pd.Series({
-            DataColumns.INFRASTRUCTURE_ID: "fast_charge",
-            DataColumns.CHARGER_POWER: 350.0,  # Fast charger
-            DataColumns.CHARGER_EFFICIENCY: 0.95,
-            DataColumns.UTILIZATION_HOURS: 22,  # High utilization
-        })
-        
+        high_util_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "high_util",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: 540.0,
+                DataColumns.RANGE_KM: 300.0,
+                DataColumns.BATTERY_EFFICIENCY: 0.9,
+            }
+        )
+
+        infra = pd.Series(
+            {
+                DataColumns.INFRASTRUCTURE_ID: "fast_charge",
+                DataColumns.CHARGER_POWER: 350.0,  # Fast charger
+                DataColumns.CHARGER_EFFICIENCY: 0.95,
+                DataColumns.UTILIZATION_HOURS: 22,  # High utilization
+            }
+        )
+
         # Very high annual km (500km/day average)
         req = calculate_charging_requirements(high_util_vehicle, 182_500, infra)
-        
+
         assert req["daily_kwh_required"] > 900  # ~180kWh/100km * 500km
         assert req["charging_hours_per_day"] > 2.5
         assert req["max_vehicles_per_charger"] < 10  # Limited by utilization
 
     def test_charging_requirements_slow_charger(self):
         """Test charging requirements with slow charger."""
-        vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "bev",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: 200.0,
-            DataColumns.RANGE_KM: 200.0,
-        })
-        
-        slow_infra = pd.Series({
-            DataColumns.INFRASTRUCTURE_ID: "slow",
-            DataColumns.CHARGER_POWER: 11.0,  # Slow AC charger
-            DataColumns.CHARGER_EFFICIENCY: 0.90,
-            DataColumns.UTILIZATION_HOURS: 12,
-        })
-        
+        vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "bev",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: 200.0,
+                DataColumns.RANGE_KM: 200.0,
+            }
+        )
+
+        slow_infra = pd.Series(
+            {
+                DataColumns.INFRASTRUCTURE_ID: "slow",
+                DataColumns.CHARGER_POWER: 11.0,  # Slow AC charger
+                DataColumns.CHARGER_EFFICIENCY: 0.90,
+                DataColumns.UTILIZATION_HOURS: 12,
+            }
+        )
+
         req = calculate_charging_requirements(vehicle, 50_000, slow_infra)
-        
+
         # With slow charger, fewer vehicles can be served
         assert req["max_vehicles_per_charger"] <= 2
         assert req["charging_hours_per_day"] > 10
 
     def test_charging_requirements_zero_utilization(self):
         """Test charging requirements with zero utilization hours."""
-        vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "bev",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: 200.0,
-            DataColumns.RANGE_KM: 200.0,
-        })
-        
-        zero_util_infra = pd.Series({
-            DataColumns.INFRASTRUCTURE_ID: "zero",
-            DataColumns.CHARGER_POWER: 50.0,
-            DataColumns.CHARGER_EFFICIENCY: 0.95,
-            DataColumns.UTILIZATION_HOURS: 0,  # No utilization
-        })
-        
+        vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "bev",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: 200.0,
+                DataColumns.RANGE_KM: 200.0,
+            }
+        )
+
+        zero_util_infra = pd.Series(
+            {
+                DataColumns.INFRASTRUCTURE_ID: "zero",
+                DataColumns.CHARGER_POWER: 50.0,
+                DataColumns.CHARGER_EFFICIENCY: 0.95,
+                DataColumns.UTILIZATION_HOURS: 0,  # No utilization
+            }
+        )
+
         req = calculate_charging_requirements(vehicle, 50_000, zero_util_infra)
-        
+
         # With zero utilization, should return 0 or handle gracefully
         assert req["max_vehicles_per_charger"] == 0
 
     def test_charging_requirements_diesel_vehicle(self):
         """Test charging requirements for diesel vehicle (should return zeros)."""
-        diesel_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "diesel",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.LITRES_PER100KM: 30.0,
-        })
-        
-        infra = pd.Series({
-            DataColumns.INFRASTRUCTURE_ID: "depot",
-            DataColumns.CHARGER_POWER: 80.0,
-            DataColumns.CHARGER_EFFICIENCY: 0.95,
-            DataColumns.UTILIZATION_HOURS: 8,
-        })
-        
+        diesel_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "diesel",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.LITRES_PER100KM: 30.0,
+            }
+        )
+
+        infra = pd.Series(
+            {
+                DataColumns.INFRASTRUCTURE_ID: "depot",
+                DataColumns.CHARGER_POWER: 80.0,
+                DataColumns.CHARGER_EFFICIENCY: 0.95,
+                DataColumns.UTILIZATION_HOURS: 8,
+            }
+        )
+
         req = calculate_charging_requirements(diesel_vehicle, 100_000, infra)
-        
+
         # Diesel vehicles don't need charging
         assert req["daily_kwh_required"] == 0
         assert req["charging_hours_per_day"] == 0
-        assert req["max_vehicles_per_charger"] == float('inf')
+        assert req["max_vehicles_per_charger"] == float("inf")
 
 
 class TestEnergyConsumption:
@@ -370,65 +412,75 @@ class TestEnergyConsumption:
 
     def test_calculate_energy_consumption_bev(self):
         """Test BEV energy consumption calculation."""
-        bev_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "bev",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: 540.0,
-            DataColumns.RANGE_KM: 300.0,
-        })
-        
+        bev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "bev",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: 540.0,
+                DataColumns.RANGE_KM: 300.0,
+            }
+        )
+
         consumption = calculate_energy_consumption(bev_vehicle)
-        
+
         # 540 kWh / 300 km = 180 kWh/100km
         assert math.isclose(consumption, 180.0, rel_tol=0.01)
 
     def test_calculate_energy_consumption_diesel(self):
         """Test diesel energy consumption calculation."""
-        diesel_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "diesel",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.LITRES_PER100KM: 35.0,  # L/100km
-        })
-        
+        diesel_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "diesel",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.LITRES_PER100KM: 35.0,  # L/100km
+            }
+        )
+
         consumption = calculate_energy_consumption(diesel_vehicle)
-        
+
         # Should return diesel consumption directly
         assert consumption == 35.0
 
     def test_calculate_energy_consumption_phev(self):
         """Test PHEV energy consumption calculation."""
-        phev_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "phev",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.PHEV,
-            DataColumns.LITRES_PER100KM: 25.0,
-            DataColumns.BATTERY_CAPACITY_KWH: 30.0,
-            DataColumns.RANGE_KM: 50.0,  # Electric range
-        })
-        
+        phev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "phev",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.PHEV,
+                DataColumns.LITRES_PER100KM: 25.0,
+                DataColumns.BATTERY_CAPACITY_KWH: 30.0,
+                DataColumns.RANGE_KM: 50.0,  # Electric range
+            }
+        )
+
         consumption = calculate_energy_consumption(phev_vehicle)
-        
+
         # PHEV should return combined consumption
         assert consumption > 0
 
     def test_energy_consumption_edge_cases(self):
         """Test energy consumption with edge cases."""
         # Zero range
-        zero_range_vehicle = pd.Series({
-            DataColumns.VEHICLE_ID: "zero",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.BATTERY_CAPACITY_KWH: 100.0,
-            DataColumns.RANGE_KM: 0.0,
-        })
-        
+        zero_range_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "zero",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.BATTERY_CAPACITY_KWH: 100.0,
+                DataColumns.RANGE_KM: 0.0,
+            }
+        )
+
         with pytest.raises(Exception):  # Division by zero
             calculate_energy_consumption(zero_range_vehicle)
 
         # Missing battery capacity
-        missing_battery = pd.Series({
-            DataColumns.VEHICLE_ID: "missing",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.RANGE_KM: 300.0,
-        })
-        
+        missing_battery = pd.Series(
+            {
+                DataColumns.VEHICLE_ID: "missing",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.RANGE_KM: 300.0,
+            }
+        )
+
         with pytest.raises(Exception):  # Missing required field
             calculate_energy_consumption(missing_battery)

--- a/tco_app/tests/unit/domain/test_externalities.py
+++ b/tco_app/tests/unit/domain/test_externalities.py
@@ -102,285 +102,306 @@ class TestDetailedExternalities:
     @pytest.fixture
     def externality_params(self):
         """Create comprehensive externality parameters."""
-        return pd.Series({
-            DataColumns.CONGESTION_COST: 0.05,  # per km
-            DataColumns.NOISE_COST: 0.02,  # per km
-            DataColumns.POLLUTION_COST: 0.03,  # per km
-            DataColumns.ACCIDENT_COST: 0.01,  # per km
-            DataColumns.INFRASTRUCTURE_WEAR_COST: 0.02,  # per km
-        })
+        return pd.Series(
+            {
+                DataColumns.CONGESTION_COST: 0.05,  # per km
+                DataColumns.NOISE_COST: 0.02,  # per km
+                DataColumns.POLLUTION_COST: 0.03,  # per km
+                DataColumns.ACCIDENT_COST: 0.01,  # per km
+                DataColumns.INFRASTRUCTURE_WEAR_COST: 0.02,  # per km
+            }
+        )
 
     def test_bev_lower_externalities(self, externality_params):
         """Test that BEVs have lower externalities than diesel."""
-        bev_vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.VEHICLE_WEIGHT: 25000,  # kg
-            DataColumns.NOISE_REDUCTION_FACTOR: 0.7,  # 30% quieter
-        })
-        
-        diesel_vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.VEHICLE_WEIGHT: 20000,  # kg
-        })
-        
+        bev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.VEHICLE_WEIGHT: 25000,  # kg
+                DataColumns.NOISE_REDUCTION_FACTOR: 0.7,  # 30% quieter
+            }
+        )
+
+        diesel_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.VEHICLE_WEIGHT: 20000,  # kg
+            }
+        )
+
         bev_ext = calculate_externalities(
             bev_vehicle, externality_params, 100000, 10, 0.05
         )
-        
+
         diesel_ext = calculate_externalities(
             diesel_vehicle, externality_params, 100000, 10, 0.05
         )
-        
+
         # BEV should have lower total externalities
-        assert bev_ext['externality_per_km'] < diesel_ext['externality_per_km']
-        
+        assert bev_ext["externality_per_km"] < diesel_ext["externality_per_km"]
+
         # BEV should have lower noise costs specifically
-        assert bev_ext['noise_cost_per_km'] < diesel_ext['noise_cost_per_km']
-        
+        assert bev_ext["noise_cost_per_km"] < diesel_ext["noise_cost_per_km"]
+
         # BEV should have zero local pollution
-        assert bev_ext.get('local_pollution_cost_per_km', 0) == 0
+        assert bev_ext.get("local_pollution_cost_per_km", 0) == 0
 
     def test_phev_externalities(self, externality_params):
         """Test PHEV externalities (between BEV and diesel)."""
-        phev_vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.PHEV,
-            DataColumns.VEHICLE_WEIGHT: 22000,
-            DataColumns.ELECTRIC_RANGE: 80,  # km
-            DataColumns.DAILY_DISTANCE: 120,  # km
-        })
-        
+        phev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.PHEV,
+                DataColumns.VEHICLE_WEIGHT: 22000,
+                DataColumns.ELECTRIC_RANGE: 80,  # km
+                DataColumns.DAILY_DISTANCE: 120,  # km
+            }
+        )
+
         phev_ext = calculate_externalities(
             phev_vehicle, externality_params, 100000, 10, 0.05
         )
-        
+
         # PHEV should have some pollution (when using diesel)
-        assert phev_ext['externality_per_km'] > 0
-        
+        assert phev_ext["externality_per_km"] > 0
+
         # Electric portion should reduce overall externalities
         electric_fraction = min(80 / 120, 1.0)  # About 67% electric
-        assert phev_ext.get('electric_driving_fraction', 0) > 0.5
+        assert phev_ext.get("electric_driving_fraction", 0) > 0.5
 
     def test_weight_based_infrastructure_wear(self, externality_params):
         """Test that heavier vehicles cause more infrastructure wear."""
-        light_vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.VEHICLE_WEIGHT: 18000,  # Light truck
-        })
-        
-        heavy_vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.VEHICLE_WEIGHT: 40000,  # Heavy truck
-        })
-        
+        light_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.VEHICLE_WEIGHT: 18000,  # Light truck
+            }
+        )
+
+        heavy_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.VEHICLE_WEIGHT: 40000,  # Heavy truck
+            }
+        )
+
         light_ext = calculate_externalities(
             light_vehicle, externality_params, 100000, 10, 0.05
         )
-        
+
         heavy_ext = calculate_externalities(
             heavy_vehicle, externality_params, 100000, 10, 0.05
         )
-        
+
         # Heavier vehicle should have higher infrastructure wear cost
-        assert (
-            heavy_ext.get('infrastructure_wear_per_km', 0) > 
-            light_ext.get('infrastructure_wear_per_km', 0)
+        assert heavy_ext.get("infrastructure_wear_per_km", 0) > light_ext.get(
+            "infrastructure_wear_per_km", 0
         )
 
     def test_total_externality_cost_calculation(self, externality_params):
         """Test total externality cost over vehicle lifetime."""
-        vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.VEHICLE_WEIGHT: 25000,
-        })
-        
+        vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.VEHICLE_WEIGHT: 25000,
+            }
+        )
+
         annual_kms = 80000
         truck_life_years = 8
         discount_rate = 0.05
-        
+
         externalities = calculate_externalities(
             vehicle, externality_params, annual_kms, truck_life_years, discount_rate
         )
-        
+
         total_cost = calculate_total_externality_cost(
             externalities, annual_kms, truck_life_years, discount_rate
         )
-        
+
         # Total cost should include all components
-        assert 'annual_externality_cost' in total_cost
-        assert 'lifetime_externality_cost' in total_cost
-        assert 'npv_externality_cost' in total_cost
-        
+        assert "annual_externality_cost" in total_cost
+        assert "lifetime_externality_cost" in total_cost
+        assert "npv_externality_cost" in total_cost
+
         # Annual cost calculation
-        expected_annual = externalities['externality_per_km'] * annual_kms
-        assert abs(total_cost['annual_externality_cost'] - expected_annual) < 0.01
-        
+        expected_annual = externalities["externality_per_km"] * annual_kms
+        assert abs(total_cost["annual_externality_cost"] - expected_annual) < 0.01
+
         # Lifetime cost (undiscounted)
         expected_lifetime = expected_annual * truck_life_years
-        assert abs(total_cost['lifetime_externality_cost'] - expected_lifetime) < 1.0
-        
+        assert abs(total_cost["lifetime_externality_cost"] - expected_lifetime) < 1.0
+
         # NPV should be less than lifetime due to discounting
-        assert total_cost['npv_externality_cost'] < total_cost['lifetime_externality_cost']
+        assert (
+            total_cost["npv_externality_cost"] < total_cost["lifetime_externality_cost"]
+        )
 
     def test_social_tco_integration(self, externality_params):
         """Test integration of externalities into social TCO."""
-        vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.VEHICLE_WEIGHT: 24000,
-        })
-        
+        vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.VEHICLE_WEIGHT: 24000,
+            }
+        )
+
         externalities = calculate_externalities(
             vehicle, externality_params, 100000, 10, 0.05
         )
-        
-        total_ext = calculate_total_externality_cost(
-            externalities, 100000, 10, 0.05
-        )
-        
+
+        total_ext = calculate_total_externality_cost(externalities, 100000, 10, 0.05)
+
         # Mock TCO results
         tco_results = {
-            'npv_total_cost': 800000,
-            'cost_per_km': 0.80,
-            'annual_kms': 100000,
-            'truck_life_years': 10,
-            'payload_t': 25,
+            "npv_total_cost": 800000,
+            "cost_per_km": 0.80,
+            "annual_kms": 100000,
+            "truck_life_years": 10,
+            "payload_t": 25,
         }
-        
+
         social_tco = calculate_social_tco(tco_results, total_ext)
-        
+
         # Social TCO should add externalities to private TCO
-        assert social_tco['social_tco_lifetime'] > tco_results['npv_total_cost']
-        assert social_tco['social_tco_lifetime'] == (
-            tco_results['npv_total_cost'] + total_ext['npv_externality_cost']
+        assert social_tco["social_tco_lifetime"] > tco_results["npv_total_cost"]
+        assert social_tco["social_tco_lifetime"] == (
+            tco_results["npv_total_cost"] + total_ext["npv_externality_cost"]
         )
-        
+
         # Cost per km should also increase
-        assert social_tco['social_cost_per_km'] > tco_results['cost_per_km']
-        
+        assert social_tco["social_cost_per_km"] > tco_results["cost_per_km"]
+
         # Cost per ton-km calculation
-        assert social_tco['social_cost_per_t_km'] == (
-            social_tco['social_cost_per_km'] / tco_results['payload_t']
+        assert social_tco["social_cost_per_t_km"] == (
+            social_tco["social_cost_per_km"] / tco_results["payload_t"]
         )
 
     def test_externality_comparison(self, externality_params):
         """Test comparison of externalities between vehicles."""
         bev_ext = {
-            'externality_per_km': 0.08,
-            'congestion_cost_per_km': 0.05,
-            'noise_cost_per_km': 0.014,  # 30% reduction
-            'pollution_cost_per_km': 0.0,
-            'npv_externality_cost': 50000,
+            "externality_per_km": 0.08,
+            "congestion_cost_per_km": 0.05,
+            "noise_cost_per_km": 0.014,  # 30% reduction
+            "pollution_cost_per_km": 0.0,
+            "npv_externality_cost": 50000,
         }
-        
+
         diesel_ext = {
-            'externality_per_km': 0.13,
-            'congestion_cost_per_km': 0.05,
-            'noise_cost_per_km': 0.02,
-            'pollution_cost_per_km': 0.03,
-            'npv_externality_cost': 80000,
+            "externality_per_km": 0.13,
+            "congestion_cost_per_km": 0.05,
+            "noise_cost_per_km": 0.02,
+            "pollution_cost_per_km": 0.03,
+            "npv_externality_cost": 80000,
         }
-        
+
         comparison = prepare_externality_comparison(bev_ext, diesel_ext)
-        
+
         # BEV should have savings
-        assert comparison['total_savings'] == 0.05  # per km
-        assert comparison['noise_savings'] == 0.006
-        assert comparison['pollution_savings'] == 0.03
-        assert comparison['congestion_savings'] == 0.0  # Same for both
-        assert comparison['lifetime_savings'] == 30000  # NPV difference
+        assert comparison["total_savings"] == 0.05  # per km
+        assert comparison["noise_savings"] == 0.006
+        assert comparison["pollution_savings"] == 0.03
+        assert comparison["congestion_savings"] == 0.0  # Same for both
+        assert comparison["lifetime_savings"] == 30000  # NPV difference
 
     def test_social_benefit_metrics(self):
         """Test calculation of social benefit metrics."""
         bev_results = {
-            'acquisition_cost': 400000,
-            'annual_costs': {'annual_operating_cost': 40000},
-            'externalities': {'npv_externality_cost': 50000},
-            'tco': {'npv_total_cost': 700000},
+            "acquisition_cost": 400000,
+            "annual_costs": {"annual_operating_cost": 40000},
+            "externalities": {"npv_externality_cost": 50000},
+            "tco": {"npv_total_cost": 700000},
         }
-        
+
         diesel_results = {
-            'acquisition_cost': 300000,
-            'annual_costs': {'annual_operating_cost': 55000},
-            'externalities': {'npv_externality_cost': 80000},
-            'tco': {'npv_total_cost': 750000},
+            "acquisition_cost": 300000,
+            "annual_costs": {"annual_operating_cost": 55000},
+            "externalities": {"npv_externality_cost": 80000},
+            "tco": {"npv_total_cost": 750000},
         }
-        
+
         metrics = calculate_social_benefit_metrics(
             bev_results, diesel_results, 100000, 10, 0.05
         )
-        
+
         # Social benefit = externality savings
-        assert metrics['social_benefit'] == 30000  # 80000 - 50000
-        
+        assert metrics["social_benefit"] == 30000  # 80000 - 50000
+
         # Private cost difference
-        assert metrics['private_cost_difference'] == -50000  # 700000 - 750000
-        
+        assert metrics["private_cost_difference"] == -50000  # 700000 - 750000
+
         # Social benefit cost ratio
         # Ratio = social benefit / private cost increase
         # But here BEV has lower private cost too, so ratio should be very high
-        assert metrics['social_benefit_cost_ratio'] > 1.0
-        
+        assert metrics["social_benefit_cost_ratio"] > 1.0
+
         # Net social value = social benefit + private savings
-        assert metrics['net_social_value'] == 80000  # 30000 + 50000
+        assert metrics["net_social_value"] == 80000  # 30000 + 50000
 
     def test_zero_externality_parameters(self):
         """Test handling of zero externality costs."""
-        zero_params = pd.Series({
-            DataColumns.CONGESTION_COST: 0.0,
-            DataColumns.NOISE_COST: 0.0,
-            DataColumns.POLLUTION_COST: 0.0,
-        })
-        
-        vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.VEHICLE_WEIGHT: 25000,
-        })
-        
-        externalities = calculate_externalities(
-            vehicle, zero_params, 100000, 10, 0.05
+        zero_params = pd.Series(
+            {
+                DataColumns.CONGESTION_COST: 0.0,
+                DataColumns.NOISE_COST: 0.0,
+                DataColumns.POLLUTION_COST: 0.0,
+            }
         )
-        
-        assert externalities['externality_per_km'] == 0.0
-        assert externalities.get('npv_externality_cost', 0) == 0.0
+
+        vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.VEHICLE_WEIGHT: 25000,
+            }
+        )
+
+        externalities = calculate_externalities(vehicle, zero_params, 100000, 10, 0.05)
+
+        assert externalities["externality_per_km"] == 0.0
+        assert externalities.get("npv_externality_cost", 0) == 0.0
 
     def test_negative_discount_rate(self, externality_params):
         """Test handling of negative discount rates (unusual but possible)."""
-        vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.VEHICLE_WEIGHT: 25000,
-        })
-        
+        vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.VEHICLE_WEIGHT: 25000,
+            }
+        )
+
         # Negative discount rate means future costs are worth more
         externalities = calculate_externalities(
             vehicle, externality_params, 100000, 10, -0.02
         )
-        
-        total_cost = calculate_total_externality_cost(
-            externalities, 100000, 10, -0.02
-        )
-        
+
+        total_cost = calculate_total_externality_cost(externalities, 100000, 10, -0.02)
+
         # NPV should be higher than undiscounted lifetime cost
-        assert total_cost['npv_externality_cost'] > total_cost['lifetime_externality_cost']
+        assert (
+            total_cost["npv_externality_cost"] > total_cost["lifetime_externality_cost"]
+        )
 
     def test_very_long_vehicle_life(self, externality_params):
         """Test calculations with very long vehicle lifetime."""
-        vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.VEHICLE_WEIGHT: 25000,
-        })
-        
+        vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.VEHICLE_WEIGHT: 25000,
+            }
+        )
+
         # 25-year vehicle life
         externalities = calculate_externalities(
             vehicle, externality_params, 100000, 25, 0.05
         )
-        
-        total_cost = calculate_total_externality_cost(
-            externalities, 100000, 25, 0.05
-        )
-        
+
+        total_cost = calculate_total_externality_cost(externalities, 100000, 25, 0.05)
+
         # Should handle long timeframes correctly
-        assert total_cost['lifetime_externality_cost'] > 0
-        assert total_cost['npv_externality_cost'] > 0
-        
+        assert total_cost["lifetime_externality_cost"] > 0
+        assert total_cost["npv_externality_cost"] > 0
+
         # Discounting effect should be stronger with longer timeframe
-        discount_factor = total_cost['npv_externality_cost'] / total_cost['lifetime_externality_cost']
+        discount_factor = (
+            total_cost["npv_externality_cost"] / total_cost["lifetime_externality_cost"]
+        )
         assert discount_factor < 0.7  # Significant discounting over 25 years

--- a/tco_app/tests/unit/domain/test_finance.py
+++ b/tco_app/tests/unit/domain/test_finance.py
@@ -41,12 +41,12 @@ class TestFinanceCalculations:
             standard_fees["vehicle_id"] == articulated_bev_vehicle["vehicle_id"]
         ]
         annual = calculate_annual_costs(
-            articulated_bev_vehicle, 
-            bev_fees, 
+            articulated_bev_vehicle,
+            bev_fees,
             0.5,  # energy_cost_per_km
             100_000,  # annual_kms
             standard_incentives,  # incentives_data
-            apply_incentives=False
+            apply_incentives=False,
         )
         acq = calculate_acquisition_cost(
             articulated_bev_vehicle,
@@ -98,21 +98,29 @@ class TestFinanceCalculations:
 
     def test_acquisition_cost_with_series_input(self):
         """Test acquisition cost handles Series input (from repository)."""
-        vehicle_data = pd.Series({
-            DataColumns.MSRP_PRICE: 200000,
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.VEHICLE_ID: "BEV001",
-        })
+        vehicle_data = pd.Series(
+            {
+                DataColumns.MSRP_PRICE: 200000,
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.VEHICLE_ID: "BEV001",
+            }
+        )
 
-        fees_data = pd.Series({
-            'stamp_duty_price': 500,
-            'registration_annual_price': 2000,
-        })
+        fees_data = pd.Series(
+            {
+                "stamp_duty_price": 500,
+                "registration_annual_price": 2000,
+            }
+        )
 
         # Empty incentives DataFrame
-        incentives_data = pd.DataFrame(columns=['incentive_flag', 'drivetrain', 'incentive_type', 'incentive_rate'])
+        incentives_data = pd.DataFrame(
+            columns=["incentive_flag", "drivetrain", "incentive_type", "incentive_rate"]
+        )
 
-        result = calculate_acquisition_cost(vehicle_data, fees_data, incentives_data, apply_incentives=False)
+        result = calculate_acquisition_cost(
+            vehicle_data, fees_data, incentives_data, apply_incentives=False
+        )
 
         # Base price + stamp duty
         expected = 200000 + 500
@@ -120,19 +128,25 @@ class TestFinanceCalculations:
 
     def test_acquisition_cost_without_incentives(self):
         """Test acquisition cost calculation without incentives."""
-        vehicle_data = pd.Series({
-            DataColumns.MSRP_PRICE: 150000,
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.VEHICLE_ID: "DIESEL001",
-        })
+        vehicle_data = pd.Series(
+            {
+                DataColumns.MSRP_PRICE: 150000,
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.VEHICLE_ID: "DIESEL001",
+            }
+        )
 
-        fees_data = pd.Series({
-            'stamp_duty_price': 1500,
-            'registration_annual_price': 400,
-        })
+        fees_data = pd.Series(
+            {
+                "stamp_duty_price": 1500,
+                "registration_annual_price": 400,
+            }
+        )
 
         # Empty incentives DataFrame
-        incentives_data = pd.DataFrame(columns=['incentive_flag', 'drivetrain', 'incentive_type', 'incentive_rate'])
+        incentives_data = pd.DataFrame(
+            columns=["incentive_flag", "drivetrain", "incentive_type", "incentive_rate"]
+        )
 
         cost = calculate_acquisition_cost(
             vehicle_data, fees_data, incentives_data, apply_incentives=False
@@ -144,76 +158,96 @@ class TestFinanceCalculations:
     def test_annual_costs_calculation(self):
         """Test annual costs calculation for different vehicle types."""
         # BEV vehicle
-        bev_vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.VEHICLE_ID: "BEV001",
-        })
+        bev_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.VEHICLE_ID: "BEV001",
+            }
+        )
 
-        bev_fees = pd.Series({
-            'insurance_annual_price': 5000,
-            'registration_annual_price': 300,
-            'maintenance_perkm_price': 0.05,
-        })
+        bev_fees = pd.Series(
+            {
+                "insurance_annual_price": 5000,
+                "registration_annual_price": 300,
+                "maintenance_perkm_price": 0.05,
+            }
+        )
 
         # Empty incentives DataFrame
-        incentives_data = pd.DataFrame(columns=['incentive_flag', 'drivetrain', 'incentive_type', 'incentive_rate'])
+        incentives_data = pd.DataFrame(
+            columns=["incentive_flag", "drivetrain", "incentive_type", "incentive_rate"]
+        )
 
         annual_bev = calculate_annual_costs(
-            bev_vehicle, bev_fees, 0.30, 100000,  # energy_cost_per_km, annual_kms
-            incentives_data, apply_incentives=False
+            bev_vehicle,
+            bev_fees,
+            0.30,
+            100000,  # energy_cost_per_km, annual_kms
+            incentives_data,
+            apply_incentives=False,
         )
 
         expected_bev = {
-            'annual_energy_cost': 0.30 * 100000,
-            'annual_maintenance_cost': 0.05 * 100000,
-            'registration_annual': 300,
-            'insurance_annual': 5000,
-            'annual_operating_cost': 0.30 * 100000 + 0.05 * 100000 + 300 + 5000,
+            "annual_energy_cost": 0.30 * 100000,
+            "annual_maintenance_cost": 0.05 * 100000,
+            "registration_annual": 300,
+            "insurance_annual": 5000,
+            "annual_operating_cost": 0.30 * 100000 + 0.05 * 100000 + 300 + 5000,
         }
 
         assert annual_bev == expected_bev
 
         # Diesel vehicle
-        diesel_vehicle = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.VEHICLE_ID: "DIESEL001",
-        })
+        diesel_vehicle = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.VEHICLE_ID: "DIESEL001",
+            }
+        )
 
-        diesel_fees = pd.Series({
-            'insurance_annual_price': 4500,
-            'registration_annual_price': 250,
-            'maintenance_perkm_price': 0.08,
-        })
+        diesel_fees = pd.Series(
+            {
+                "insurance_annual_price": 4500,
+                "registration_annual_price": 250,
+                "maintenance_perkm_price": 0.08,
+            }
+        )
 
         annual_diesel = calculate_annual_costs(
-            diesel_vehicle, diesel_fees, 0.40, 100000,
-            incentives_data, apply_incentives=False
+            diesel_vehicle,
+            diesel_fees,
+            0.40,
+            100000,
+            incentives_data,
+            apply_incentives=False,
         )
 
         expected_diesel = {
-            'annual_energy_cost': 0.40 * 100000,
-            'annual_maintenance_cost': 0.08 * 100000,
-            'registration_annual': 250,
-            'insurance_annual': 4500,
-            'annual_operating_cost': 0.40 * 100000 + 0.08 * 100000 + 250 + 4500,
+            "annual_energy_cost": 0.40 * 100000,
+            "annual_maintenance_cost": 0.08 * 100000,
+            "registration_annual": 250,
+            "insurance_annual": 4500,
+            "annual_operating_cost": 0.40 * 100000 + 0.08 * 100000 + 250 + 4500,
         }
 
         assert annual_diesel == expected_diesel
 
     def test_tco_npv_calculation(self):
         """Test TCO and NPV calculations."""
-        vehicle_data = pd.Series({
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.PAYLOAD_T: 20.0,
-        })
+        vehicle_data = pd.Series(
+            {
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.PAYLOAD_T: 20.0,
+            }
+        )
 
         fees_data = pd.DataFrame()  # Not used in calculate_tco directly
-        
+
         annual_costs = {
-            'annual_operating_cost': 50000,
-            'annual_energy_cost': 30000,
-            'annual_insurance': 5000,
-            'annual_fees': 300,
+            "annual_operating_cost": 50000,
+            "annual_energy_cost": 30000,
+            "annual_insurance": 5000,
+            "annual_fees": 300,
         }
 
         acquisition_cost = 300000
@@ -223,7 +257,7 @@ class TestFinanceCalculations:
         truck_life_years = 10
 
         # Calculate NPV of annual costs with 0% discount rate
-        npv_annual_cost_0 = annual_costs['annual_operating_cost'] * truck_life_years
+        npv_annual_cost_0 = annual_costs["annual_operating_cost"] * truck_life_years
 
         # Test with 0% discount rate
         tco_0 = calculate_tco(
@@ -239,20 +273,14 @@ class TestFinanceCalculations:
         )
 
         # With 0% discount, NPV = acquisition + (annual costs * years) - residual
-        expected_npv_0 = (
-            acquisition_cost 
-            + npv_annual_cost_0
-            - residual_value
-        )
+        expected_npv_0 = acquisition_cost + npv_annual_cost_0 - residual_value
 
-        assert abs(tco_0['npv_total_cost'] - expected_npv_0) < 1.0
+        assert abs(tco_0["npv_total_cost"] - expected_npv_0) < 1.0
 
         # Test with 5% discount rate
         discount_rate = 0.05
         npv_annual_cost_5 = calculate_npv(
-            annual_costs['annual_operating_cost'],
-            discount_rate,
-            truck_life_years
+            annual_costs["annual_operating_cost"], discount_rate, truck_life_years
         )
 
         tco_5 = calculate_tco(
@@ -268,18 +296,18 @@ class TestFinanceCalculations:
         )
 
         # NPV with discount should be less than without
-        assert tco_5['npv_total_cost'] < tco_0['npv_total_cost']
+        assert tco_5["npv_total_cost"] < tco_0["npv_total_cost"]
 
         # Check cost per km calculation
-        expected_cost_per_km = tco_5['npv_total_cost'] / (annual_kms * truck_life_years)
-        assert abs(tco_5['tco_per_km'] - expected_cost_per_km) < 0.001
+        expected_cost_per_km = tco_5["npv_total_cost"] / (annual_kms * truck_life_years)
+        assert abs(tco_5["tco_per_km"] - expected_cost_per_km) < 0.001
 
     def test_infrastructure_costs_calculation(self):
         """Test infrastructure cost calculations with different parameters."""
         infrastructure_data = {
             DataColumns.INFRASTRUCTURE_PRICE: 100000,
-            'service_life_years': 10,
-            'maintenance_percent': 0.05,
+            "service_life_years": 10,
+            "maintenance_percent": 0.05,
         }
 
         # Test with single vehicle
@@ -291,8 +319,8 @@ class TestFinanceCalculations:
         )
 
         assert infra_costs_single[DataColumns.INFRASTRUCTURE_PRICE] == 100000
-        assert infra_costs_single['annual_maintenance'] == 100000 * 0.05
-        assert infra_costs_single['npv_infrastructure'] > 100000  # Due to maintenance
+        assert infra_costs_single["annual_maintenance"] == 100000 * 0.05
+        assert infra_costs_single["npv_infrastructure"] > 100000  # Due to maintenance
 
         # Test with fleet
         infra_costs_fleet = calculate_infrastructure_costs(
@@ -303,45 +331,50 @@ class TestFinanceCalculations:
         )
 
         # Per-vehicle cost should be lower with larger fleet
-        assert infra_costs_fleet['npv_per_vehicle'] == infra_costs_fleet['npv_infrastructure'] / 10
+        assert (
+            infra_costs_fleet["npv_per_vehicle"]
+            == infra_costs_fleet["npv_infrastructure"] / 10
+        )
 
     def test_infrastructure_incentives(self):
         """Test infrastructure incentive application."""
         infrastructure_costs = {
             DataColumns.INFRASTRUCTURE_PRICE: 150000,
-            'npv_infrastructure': 200000,
-            'npv_per_vehicle': 15000,
+            "npv_infrastructure": 200000,
+            "npv_per_vehicle": 15000,
         }
 
-        incentives = pd.DataFrame({
-            'incentive_flag': [1],
-            'incentive_type': ['charging_infrastructure_subsidy'],
-            'incentive_rate': [0.20],  # 20% subsidy
-        })
+        incentives = pd.DataFrame(
+            {
+                "incentive_flag": [1],
+                "incentive_type": ["charging_infrastructure_subsidy"],
+                "incentive_rate": [0.20],  # 20% subsidy
+            }
+        )
 
         subsidized = apply_infrastructure_incentives(
             infrastructure_costs, incentives, apply_incentives=True
         )
 
-        assert subsidized['infrastructure_price_with_incentives'] == 150000 * 0.8
-        assert subsidized['npv_per_vehicle_with_incentives'] == 15000 * 0.8
-        assert subsidized['npv_infrastructure_with_incentives'] == 200000 * 0.8
-        assert subsidized['subsidy_rate'] == 0.20
+        assert subsidized["infrastructure_price_with_incentives"] == 150000 * 0.8
+        assert subsidized["npv_per_vehicle_with_incentives"] == 15000 * 0.8
+        assert subsidized["npv_infrastructure_with_incentives"] == 200000 * 0.8
+        assert subsidized["subsidy_rate"] == 0.20
 
     def test_integrate_infrastructure_with_tco(self):
         """Test integration of infrastructure costs with TCO."""
         tco_results = {
-            'npv_total_cost': 500000,
-            'tco_per_km': 0.50,
-            'annual_kms': 100000,
-            'truck_life_years': 10,
+            "npv_total_cost": 500000,
+            "tco_per_km": 0.50,
+            "annual_kms": 100000,
+            "truck_life_years": 10,
             DataColumns.PAYLOAD_T: 20,
         }
 
         infrastructure_costs = {
-            'npv_infrastructure_with_incentives': 180000,
-            'npv_per_vehicle_with_incentives': 18000,
-            'npv_per_vehicle': 20000,
+            "npv_infrastructure_with_incentives": 180000,
+            "npv_per_vehicle_with_incentives": 18000,
+            "npv_per_vehicle": 20000,
         }
 
         combined = integrate_infrastructure_with_tco(
@@ -349,24 +382,28 @@ class TestFinanceCalculations:
         )
 
         # Should add infrastructure to total
-        assert combined['npv_total_cost'] == 500000 + 18000
-        assert combined['infrastructure_costs'] == infrastructure_costs
+        assert combined["npv_total_cost"] == 500000 + 18000
+        assert combined["infrastructure_costs"] == infrastructure_costs
         # TCO per km should be recalculated
         total_kms = 100000 * 10
-        assert combined['tco_per_km'] == combined['npv_total_cost'] / total_kms
+        assert combined["tco_per_km"] == combined["npv_total_cost"] / total_kms
 
     def test_edge_cases(self):
         """Test edge cases in finance calculations."""
         # Vehicle with zero price
-        zero_price_vehicle = pd.Series({
-            DataColumns.MSRP_PRICE: 0,
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-        })
+        zero_price_vehicle = pd.Series(
+            {
+                DataColumns.MSRP_PRICE: 0,
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+            }
+        )
 
-        zero_fees = pd.Series({
-            'stamp_duty_price': 0,
-            'registration_annual_price': 0,
-        })
+        zero_fees = pd.Series(
+            {
+                "stamp_duty_price": 0,
+                "registration_annual_price": 0,
+            }
+        )
 
         incentives = pd.DataFrame()
 
@@ -381,8 +418,8 @@ class TestFinanceCalculations:
         # Infrastructure with zero fleet size
         infrastructure_data = {
             DataColumns.INFRASTRUCTURE_PRICE: 100000,
-            'service_life_years': 10,
-            'maintenance_percent': 0.05,
+            "service_life_years": 10,
+            "maintenance_percent": 0.05,
         }
 
         infra_costs = calculate_infrastructure_costs(
@@ -393,28 +430,34 @@ class TestFinanceCalculations:
         )
 
         # Should calculate correctly for single vehicle
-        assert infra_costs['per_vehicle_annual_cost'] > 0
-        assert infra_costs['npv_per_vehicle'] > 0
+        assert infra_costs["per_vehicle_annual_cost"] > 0
+        assert infra_costs["npv_per_vehicle"] > 0
 
     def test_negative_values_handling(self):
         """Test handling of negative values (e.g., very high incentives)."""
-        vehicle_data = pd.Series({
-            DataColumns.MSRP_PRICE: 100000,
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-        })
+        vehicle_data = pd.Series(
+            {
+                DataColumns.MSRP_PRICE: 100000,
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+            }
+        )
 
-        fees_data = pd.Series({
-            'stamp_duty_price': 5000,
-            'registration_annual_price': 300,
-        })
+        fees_data = pd.Series(
+            {
+                "stamp_duty_price": 5000,
+                "registration_annual_price": 300,
+            }
+        )
 
         # Very high incentives
-        incentives = pd.DataFrame({
-            'incentive_flag': [1],
-            'drivetrain': [Drivetrain.BEV],
-            'incentive_type': ['purchase_subsidy'],
-            'incentive_rate': [1.5],  # 150% incentive (more than vehicle cost)
-        })
+        incentives = pd.DataFrame(
+            {
+                "incentive_flag": [1],
+                "drivetrain": [Drivetrain.BEV],
+                "incentive_type": ["purchase_subsidy"],
+                "incentive_rate": [1.5],  # 150% incentive (more than vehicle cost)
+            }
+        )
 
         cost = calculate_acquisition_cost(
             vehicle_data, fees_data, incentives, apply_incentives=True

--- a/tco_app/tests/unit/services/test_tco_calculation_service.py
+++ b/tco_app/tests/unit/services/test_tco_calculation_service.py
@@ -39,71 +39,87 @@ class TestTCOCalculationService:
     @pytest.fixture
     def bev_vehicle_data(self):
         """Sample BEV vehicle data."""
-        return pd.Series({
-            DataColumns.VEHICLE_ID: 1,
-            DataColumns.VEHICLE_NAME: "Test BEV Truck",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
-            DataColumns.KWH_PER100KM: 125.0,
-            DataColumns.VEHICLE_PRICE: 350000,
-            DataColumns.PAYLOAD_TONNES: 20,
-            DataColumns.VEHICLE_BATTERY_CAPACITY_KWH: 300,
-            DataColumns.MAX_ANNUAL_DISTANCE_KM: 150000,
-        })
+        return pd.Series(
+            {
+                DataColumns.VEHICLE_ID: 1,
+                DataColumns.VEHICLE_NAME: "Test BEV Truck",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.BEV,
+                DataColumns.KWH_PER100KM: 125.0,
+                DataColumns.VEHICLE_PRICE: 350000,
+                DataColumns.PAYLOAD_TONNES: 20,
+                DataColumns.VEHICLE_BATTERY_CAPACITY_KWH: 300,
+                DataColumns.MAX_ANNUAL_DISTANCE_KM: 150000,
+            }
+        )
 
     @pytest.fixture
     def diesel_vehicle_data(self):
         """Sample diesel vehicle data."""
-        return pd.Series({
-            DataColumns.VEHICLE_ID: 2,
-            DataColumns.VEHICLE_NAME: "Test Diesel Truck",
-            DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
-            DataColumns.LITRES_PER100KM: 35.0,
-            DataColumns.VEHICLE_PRICE: 150000,
-            DataColumns.PAYLOAD_TONNES: 20,
-            DataColumns.VEHICLE_BATTERY_CAPACITY_KWH: 0,
-            DataColumns.MAX_ANNUAL_DISTANCE_KM: 200000,
-        })
+        return pd.Series(
+            {
+                DataColumns.VEHICLE_ID: 2,
+                DataColumns.VEHICLE_NAME: "Test Diesel Truck",
+                DataColumns.VEHICLE_DRIVETRAIN: Drivetrain.DIESEL,
+                DataColumns.LITRES_PER100KM: 35.0,
+                DataColumns.VEHICLE_PRICE: 150000,
+                DataColumns.PAYLOAD_TONNES: 20,
+                DataColumns.VEHICLE_BATTERY_CAPACITY_KWH: 0,
+                DataColumns.MAX_ANNUAL_DISTANCE_KM: 200000,
+            }
+        )
 
     @pytest.fixture
     def financial_params(self):
         """Sample financial parameters."""
-        return pd.DataFrame({
-            ParameterKeys.PARAMETER_KEY: [
-                ParameterKeys.DISCOUNT_RATE,
-                ParameterKeys.DIESEL_PRICE,
-                ParameterKeys.CARBON_PRICE,
-                ParameterKeys.ROAD_USER_CHARGE,
-                ParameterKeys.ANNUAL_INSURANCE_COST,
-                ParameterKeys.ANNUAL_TYRE_COST,
-                ParameterKeys.ANNUAL_MAINTENANCE_COST,
-                ParameterKeys.ANNUAL_REGISTRATION_COST,
-            ],
-            'value': [0.05, 1.50, 50.0, 15000, 5000, 3000, 8000, 2000],
-        })
+        return pd.DataFrame(
+            {
+                ParameterKeys.PARAMETER_KEY: [
+                    ParameterKeys.DISCOUNT_RATE,
+                    ParameterKeys.DIESEL_PRICE,
+                    ParameterKeys.CARBON_PRICE,
+                    ParameterKeys.ROAD_USER_CHARGE,
+                    ParameterKeys.ANNUAL_INSURANCE_COST,
+                    ParameterKeys.ANNUAL_TYRE_COST,
+                    ParameterKeys.ANNUAL_MAINTENANCE_COST,
+                    ParameterKeys.ANNUAL_REGISTRATION_COST,
+                ],
+                "value": [0.05, 1.50, 50.0, 15000, 5000, 3000, 8000, 2000],
+            }
+        )
 
     @pytest.fixture
     def battery_params(self):
         """Sample battery parameters."""
-        return pd.DataFrame({
-            ParameterKeys.PARAMETER_KEY: [
-                ParameterKeys.BATTERY_PRICE_PER_KWH,
-                ParameterKeys.BATTERY_ANNUAL_DECAY_RATE,
-                ParameterKeys.BATTERY_MIN_SOH,
-            ],
-            'value': [500, 0.025, 0.8],
-        })
+        return pd.DataFrame(
+            {
+                ParameterKeys.PARAMETER_KEY: [
+                    ParameterKeys.BATTERY_PRICE_PER_KWH,
+                    ParameterKeys.BATTERY_ANNUAL_DECAY_RATE,
+                    ParameterKeys.BATTERY_MIN_SOH,
+                ],
+                "value": [500, 0.025, 0.8],
+            }
+        )
 
     @pytest.fixture
     def charging_data(self):
         """Sample charging options data."""
-        return pd.DataFrame({
-            DataColumns.CHARGING_ID: [1, 2, 3],
-            DataColumns.CHARGING_NAME: ['Depot Slow', 'Depot Fast', 'Public Ultra-Fast'],
-            DataColumns.PER_KWH_PRICE: [0.20, 0.25, 0.35],
-        })
+        return pd.DataFrame(
+            {
+                DataColumns.CHARGING_ID: [1, 2, 3],
+                DataColumns.CHARGING_NAME: [
+                    "Depot Slow",
+                    "Depot Fast",
+                    "Public Ultra-Fast",
+                ],
+                DataColumns.PER_KWH_PRICE: [0.20, 0.25, 0.35],
+            }
+        )
 
     @pytest.fixture
-    def bev_calculation_request(self, bev_vehicle_data, financial_params, battery_params, charging_data):
+    def bev_calculation_request(
+        self, bev_vehicle_data, financial_params, battery_params, charging_data
+    ):
         """Create a BEV calculation request."""
         parameters = CalculationParameters(
             annual_kms=100000,
@@ -112,25 +128,29 @@ class TestTCOCalculationService:
             diesel_price=1.50,
             carbon_price=50.0,
         )
-        
+
         return CalculationRequest(
             vehicle_data=bev_vehicle_data,
             fees_data=pd.DataFrame(),
             financial_params=financial_params,
             battery_params=battery_params,
-            emission_factors=pd.DataFrame({
-                'fuel_type': ['electricity', 'diesel'],
-                'emission_standard': ['Grid Average', 'Euro VI'],
-                'co2_per_unit': [0.5, 2.68],
-            }),
+            emission_factors=pd.DataFrame(
+                {
+                    "fuel_type": ["electricity", "diesel"],
+                    "emission_standard": ["Grid Average", "Euro VI"],
+                    "co2_per_unit": [0.5, 2.68],
+                }
+            ),
             charging_options=charging_data,
-            infrastructure_options=pd.DataFrame({
-                DataColumns.INFRASTRUCTURE_ID: [1],
-                DataColumns.INFRASTRUCTURE_DESCRIPTION: ['Depot Charger 150kW'],
-                DataColumns.INFRASTRUCTURE_PRICE: [50000],
-                DataColumns.ANNUAL_MAINTENANCE_COST: [2000],
-                DataColumns.SERVICE_LIFE_YEARS: [15],
-            }),
+            infrastructure_options=pd.DataFrame(
+                {
+                    DataColumns.INFRASTRUCTURE_ID: [1],
+                    DataColumns.INFRASTRUCTURE_DESCRIPTION: ["Depot Charger 150kW"],
+                    DataColumns.INFRASTRUCTURE_PRICE: [50000],
+                    DataColumns.ANNUAL_MAINTENANCE_COST: [2000],
+                    DataColumns.SERVICE_LIFE_YEARS: [15],
+                }
+            ),
             parameters=parameters,
             selected_charging_id=1,
             selected_infrastructure_id=1,
@@ -139,7 +159,9 @@ class TestTCOCalculationService:
         )
 
     @pytest.fixture
-    def diesel_calculation_request(self, diesel_vehicle_data, financial_params, battery_params):
+    def diesel_calculation_request(
+        self, diesel_vehicle_data, financial_params, battery_params
+    ):
         """Create a diesel calculation request."""
         parameters = CalculationParameters(
             annual_kms=100000,
@@ -148,17 +170,19 @@ class TestTCOCalculationService:
             diesel_price=1.50,
             carbon_price=50.0,
         )
-        
+
         return CalculationRequest(
             vehicle_data=diesel_vehicle_data,
             fees_data=pd.DataFrame(),
             financial_params=financial_params,
             battery_params=battery_params,
-            emission_factors=pd.DataFrame({
-                'fuel_type': ['electricity', 'diesel'],
-                'emission_standard': ['Grid Average', 'Euro VI'],
-                'co2_per_unit': [0.5, 2.68],
-            }),
+            emission_factors=pd.DataFrame(
+                {
+                    "fuel_type": ["electricity", "diesel"],
+                    "emission_standard": ["Grid Average", "Euro VI"],
+                    "co2_per_unit": [0.5, 2.68],
+                }
+            ),
             charging_options=pd.DataFrame(),
             infrastructure_options=pd.DataFrame(),
             parameters=parameters,
@@ -173,26 +197,31 @@ class TestTCOCalculationService:
         assert service.vehicle_repo == mock_vehicle_repo
         assert service.params_repo == mock_params_repo
 
-    @patch('tco_app.services.tco_calculation_service.energy')
-    @patch('tco_app.services.tco_calculation_service.finance')
-    @patch('tco_app.services.tco_calculation_service.externalities')
+    @patch("tco_app.services.tco_calculation_service.energy")
+    @patch("tco_app.services.tco_calculation_service.finance")
+    @patch("tco_app.services.tco_calculation_service.externalities")
     def test_calculate_single_vehicle_tco_bev(
-        self, mock_externalities, mock_finance, mock_energy, service, bev_calculation_request
+        self,
+        mock_externalities,
+        mock_finance,
+        mock_energy,
+        service,
+        bev_calculation_request,
     ):
         """Test TCO calculation for a BEV vehicle."""
         # Mock energy calculations
         mock_energy.calculate_energy_costs.return_value = 0.25  # $/km
         mock_energy.calculate_emissions.return_value = {
-            'co2_per_km': 0.625,
-            'annual_emissions': 62500,
-            'lifetime_emissions': 625000,
+            "co2_per_km": 0.625,
+            "annual_emissions": 62500,
+            "lifetime_emissions": 625000,
         }
         mock_energy.calculate_charging_requirements.return_value = {
-            'daily_distance': 273.97,
-            'daily_kwh_required': 342.47,
-            'charger_power': 150,
-            'charging_time_per_day': 2.28,
-            'max_vehicles_per_charger': 10.5,
+            "daily_distance": 273.97,
+            "daily_kwh_required": 342.47,
+            "charger_power": 150,
+            "charging_time_per_day": 2.28,
+            "max_vehicles_per_charger": 10.5,
         }
 
         # Mock finance calculations
@@ -203,10 +232,10 @@ class TestTCOCalculationService:
 
         # Mock externalities
         mock_externalities.calculate_externality_costs.return_value = {
-            'annual_externality_cost': 3125,
-            'lifetime_externality_cost': 31250,
-            'externality_cost_per_km': 0.03125,
-            'externality_npv': 24123,
+            "annual_externality_cost": 3125,
+            "lifetime_externality_cost": 31250,
+            "externality_cost_per_km": 0.03125,
+            "externality_npv": 24123,
         }
 
         # Call the service
@@ -217,77 +246,97 @@ class TestTCOCalculationService:
         assert result.vehicle_id == 1
         assert result.vehicle_name == "Test BEV Truck"
         assert result.drivetrain == Drivetrain.BEV
-        
+
         # Verify calculations were called correctly
         mock_energy.calculate_energy_costs.assert_called_once()
         mock_energy.calculate_emissions.assert_called_once()
         mock_finance.calculate_annual_operating_cost.assert_called_once()
         mock_finance.calculate_acquisition_cost.assert_called_once()
-        
+
         # Verify TCO metrics
         assert result.tco_per_km > 0
         assert result.tco_per_tonne_km > 0
         assert result.tco_total_lifetime > 0
         assert result.npv_total_cost > 0
 
-    def test_calculate_single_vehicle_tco_error_handling(self, service, bev_calculation_request):
+    def test_calculate_single_vehicle_tco_error_handling(
+        self, service, bev_calculation_request
+    ):
         """Test error handling in TCO calculation."""
         # Mock an error in energy calculation
-        with patch('tco_app.services.tco_calculation_service.energy.calculate_energy_costs') as mock_energy:
+        with patch(
+            "tco_app.services.tco_calculation_service.energy.calculate_energy_costs"
+        ) as mock_energy:
             mock_energy.side_effect = Exception("Energy calculation failed")
-            
+
             with pytest.raises(CalculationError) as exc_info:
                 service.calculate_single_vehicle_tco(bev_calculation_request)
-            
+
             assert "TCO calculation failed" in str(exc_info.value)
 
-    @patch('tco_app.services.tco_calculation_service.calculate_battery_replacement')
-    def test_battery_cost_calculation_bev(self, mock_battery_calc, service, bev_calculation_request):
+    @patch("tco_app.services.tco_calculation_service.calculate_battery_replacement")
+    def test_battery_cost_calculation_bev(
+        self, mock_battery_calc, service, bev_calculation_request
+    ):
         """Test battery cost calculation for BEV."""
         mock_battery_calc.return_value = {
-            'battery_replacement_year': 8,
-            'battery_replacement_cost': 150000,
-            'battery_replacement_needed': True,
+            "battery_replacement_year": 8,
+            "battery_replacement_cost": 150000,
+            "battery_replacement_needed": True,
         }
-        
+
         battery_costs = service._calculate_battery_costs(bev_calculation_request)
-        
-        assert battery_costs['battery_replacement_needed'] is True
-        assert battery_costs['battery_replacement_year'] == 8
-        assert battery_costs['battery_replacement_cost'] == 150000
+
+        assert battery_costs["battery_replacement_needed"] is True
+        assert battery_costs["battery_replacement_year"] == 8
+        assert battery_costs["battery_replacement_cost"] == 150000
 
     def test_battery_cost_calculation_diesel(self, service, diesel_calculation_request):
         """Test battery cost calculation for diesel (should return empty)."""
         battery_costs = service._calculate_battery_costs(diesel_calculation_request)
-        
-        assert battery_costs['battery_replacement_needed'] is False
-        assert battery_costs['battery_replacement_year'] is None
-        assert battery_costs['battery_replacement_cost'] == 0
 
-    def test_infrastructure_cost_calculation_bev(self, service, bev_calculation_request):
+        assert battery_costs["battery_replacement_needed"] is False
+        assert battery_costs["battery_replacement_year"] is None
+        assert battery_costs["battery_replacement_cost"] == 0
+
+    def test_infrastructure_cost_calculation_bev(
+        self, service, bev_calculation_request
+    ):
         """Test infrastructure cost calculation for BEV."""
         infra_costs = service._calculate_infrastructure_costs(bev_calculation_request)
-        
-        # Verify infrastructure costs are calculated
-        assert 'infrastructure_price' in infra_costs
-        assert infra_costs['infrastructure_price'] == 50000
-        assert infra_costs['annual_maintenance'] == 2000
-        assert infra_costs['service_life_years'] == 15
-        assert infra_costs['fleet_size'] == 10
-        
-        # Verify charging requirements
-        assert 'daily_distance' in infra_costs
-        assert infra_costs['daily_distance'] > 0
-        assert 'daily_kwh_required' in infra_costs
 
-    def test_infrastructure_cost_calculation_diesel(self, service, diesel_calculation_request):
+        # Verify infrastructure costs are calculated
+        assert "infrastructure_price" in infra_costs
+        assert infra_costs["infrastructure_price"] == 50000
+        assert infra_costs["annual_maintenance"] == 2000
+        assert infra_costs["service_life_years"] == 15
+        assert infra_costs["fleet_size"] == 10
+
+        # Verify charging requirements
+        assert "daily_distance" in infra_costs
+        assert infra_costs["daily_distance"] > 0
+        assert "daily_kwh_required" in infra_costs
+
+    def test_infrastructure_cost_calculation_diesel(
+        self, service, diesel_calculation_request
+    ):
         """Test infrastructure cost calculation for diesel (should return empty)."""
-        infra_costs = service._calculate_infrastructure_costs(diesel_calculation_request)
-        
+        infra_costs = service._calculate_infrastructure_costs(
+            diesel_calculation_request
+        )
+
         assert infra_costs == {}
 
-    @patch('tco_app.services.tco_calculation_service.sensitivity_metrics.calculate_comparative_metrics')
-    def test_compare_vehicles(self, mock_comparative_metrics, service, bev_calculation_request, diesel_calculation_request):
+    @patch(
+        "tco_app.services.tco_calculation_service.sensitivity_metrics.calculate_comparative_metrics"
+    )
+    def test_compare_vehicles(
+        self,
+        mock_comparative_metrics,
+        service,
+        bev_calculation_request,
+        diesel_calculation_request,
+    ):
         """Test vehicle comparison functionality."""
         # Mock TCO results
         bev_result = TCOResult(
@@ -316,12 +365,12 @@ class TestTCOCalculationService:
             annual_externality_cost=3125,
             lifetime_externality_cost=31250,
             externality_npv=24123,
-            charging_requirements={'daily_kwh_required': 342.47},
-            infrastructure_costs={'infrastructure_price': 50000},
+            charging_requirements={"daily_kwh_required": 342.47},
+            infrastructure_costs={"infrastructure_price": 50000},
             weighted_electricity_price=0.22,
             annual_carbon_cost=3125,
         )
-        
+
         diesel_result = TCOResult(
             vehicle_id=2,
             vehicle_name="Test Diesel",
@@ -353,23 +402,25 @@ class TestTCOCalculationService:
             weighted_electricity_price=None,
             annual_carbon_cost=4690,
         )
-        
+
         # Mock comparative metrics
         mock_comparative_metrics.return_value = {
-            'upfront_cost_difference': 230000,
-            'annual_operating_savings': 17000,
-            'price_parity_year': 13.5,
-            'emission_savings_lifetime': 313000,
-            'abatement_cost': -318.85,
-            'bev_to_diesel_tco_ratio': 0.88,
+            "upfront_cost_difference": 230000,
+            "annual_operating_savings": 17000,
+            "price_parity_year": 13.5,
+            "emission_savings_lifetime": 313000,
+            "abatement_cost": -318.85,
+            "bev_to_diesel_tco_ratio": 0.88,
         }
-        
+
         # Patch the individual TCO calculations
-        with patch.object(service, 'calculate_single_vehicle_tco') as mock_calc:
+        with patch.object(service, "calculate_single_vehicle_tco") as mock_calc:
             mock_calc.side_effect = [bev_result, diesel_result]
-            
-            comparison = service.compare_vehicles(bev_calculation_request, diesel_calculation_request)
-        
+
+            comparison = service.compare_vehicles(
+                bev_calculation_request, diesel_calculation_request
+            )
+
         # Verify comparison results
         assert isinstance(comparison, ComparisonResult)
         assert comparison.base_vehicle_result == bev_result
@@ -386,26 +437,30 @@ class TestTCOCalculationService:
         """Test TCO per-km and per-tonne-km metrics calculation."""
         tco_total = 800000
         metrics = service._calculate_tco_metrics(tco_total, bev_calculation_request)
-        
+
         expected_per_km = tco_total / (100000 * 10)  # annual_kms * truck_life_years
         expected_per_tonne_km = expected_per_km / 20  # payload_tonnes
-        
-        assert metrics['tco_per_km'] == pytest.approx(expected_per_km)
-        assert metrics['tco_per_tonne_km'] == pytest.approx(expected_per_tonne_km)
+
+        assert metrics["tco_per_km"] == pytest.approx(expected_per_km)
+        assert metrics["tco_per_tonne_km"] == pytest.approx(expected_per_tonne_km)
 
     def test_annual_costs_calculation(self, service, bev_calculation_request):
         """Test annual costs aggregation."""
         energy_costs = {
-            'energy_cost_per_km': 0.25,
-            'annual_emissions': 62500,
+            "energy_cost_per_km": 0.25,
+            "annual_emissions": 62500,
         }
-        
-        with patch('tco_app.services.tco_calculation_service.finance.calculate_annual_operating_cost') as mock_annual:
+
+        with patch(
+            "tco_app.services.tco_calculation_service.finance.calculate_annual_operating_cost"
+        ) as mock_annual:
             mock_annual.return_value = 58000
-            
-            annual_costs = service._calculate_annual_costs(bev_calculation_request, energy_costs)
-            
-            assert 'annual_operating_cost' in annual_costs
-            assert annual_costs['annual_operating_cost'] == 58000
-            assert 'annual_energy_cost' in annual_costs
-            assert annual_costs['annual_energy_cost'] == 25000  # 0.25 * 100000
+
+            annual_costs = service._calculate_annual_costs(
+                bev_calculation_request, energy_costs
+            )
+
+            assert "annual_operating_cost" in annual_costs
+            assert annual_costs["annual_operating_cost"] == 58000
+            assert "annual_energy_cost" in annual_costs
+            assert annual_costs["annual_energy_cost"] == 25000  # 0.25 * 100000


### PR DESCRIPTION
## Summary
- run `black` across project to address inconsistent formatting and long lines

## Testing
- `black tco_app/ --exclude venv`
- `flake8 tco_app/ --exclude=venv --count` *(fails: command not found)*