### PR TITLE
Remove unused helper methods

### DIFF
--- a/tco_app/services/tco_calculation_service.py
+++ b/tco_app/services/tco_calculation_service.py
@@ -378,12 +378,6 @@ class TCOCalculationService:
 
         return tco_per_km, tco_per_tonne_km
 
-    def _convert_tco_result_to_model_runner_dict(
-        self, tco_result: TCOResult, request: CalculationRequest
-    ) -> Dict[str, Any]:
-        """Thin proxy to :pyfunc:`tco_app.services.helpers.convert_tco_result_to_model_runner_dict`."""
-
-        return convert_tco_result_to_model_runner_dict(tco_result, request)
 
     def compare_vehicles(
         self,

--- a/tco_app/src/utils/data_access.py
+++ b/tco_app/src/utils/data_access.py
@@ -41,15 +41,6 @@ class ParameterRepository:
         self._cache[key] = value
         return value
 
-    def get_all(self) -> Dict[str, Any]:
-        """Get all parameters as a dictionary."""
-        return dict(zip(self.df[self.key_column], self.df[self.value_column]))
-
-    def clear_cache(self) -> None:
-        """Clear the internal cache."""
-        self._cache.clear()
-
-
 class FinancialParameters(ParameterRepository):
     """Specialised repository for financial parameters."""
 


### PR DESCRIPTION
## Summary
- drop `_convert_tco_result_to_model_runner_dict` from `TCOCalculationService`
- remove dead `get_all` and `clear_cache` helpers from `data_access`

## Testing
- `pytest -q`